### PR TITLE
Improve type hints

### DIFF
--- a/root/app/helpers/accounts-helper.php
+++ b/root/app/helpers/accounts-helper.php
@@ -115,12 +115,15 @@ function generateAccountList(): string
         $daysStr = implode(', ', $daysArr);
 
         // Parse and format cron times
-        $cronArr = array_filter(array_map('trim', explode(',', $accountData->cron)), function ($hour) {
-            return is_numeric($hour) && $hour !== '';
-        });
+        $cronArr = array_filter(
+            array_map('trim', explode(',', $accountData->cron)),
+            function (string $hour): bool {
+                return is_numeric($hour) && $hour !== '';
+            }
+        );
         $timesStr = 'Off';
         if (!empty($cronArr)) {
-            $times = array_map(function ($hour) {
+            $times = array_map(function (string $hour): string {
                 $hour = (int)$hour;
                 if ($hour === 0) {
                     return '12 am';

--- a/root/autoload.php
+++ b/root/autoload.php
@@ -1,7 +1,7 @@
 <?php
 
 // Autoload function to automatically include class files
-spl_autoload_register(function ($class_name) {
+spl_autoload_register(function (string $class_name): void {
     $file = __DIR__ . '/classes/' . $class_name . '.php';
     if (file_exists($file)) {
         require_once $file;

--- a/root/classes/DatabaseHandler.php
+++ b/root/classes/DatabaseHandler.php
@@ -158,7 +158,7 @@ class DatabaseHandler // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNam
      *
      * @return mixed
      */
-    public function single()
+    public function single(): mixed
     {
         $this->execute();
         return $this->stmt->fetch(PDO::FETCH_OBJ);

--- a/root/cron.php
+++ b/root/cron.php
@@ -21,7 +21,7 @@ require_once __DIR__ . '/autoload.php';
 new ErrorHandler();
 
 // Add a helper function for logging
-function logDebug($message)
+function logDebug(string $message): void
 {
     global $debugMode;
     if ($debugMode) {
@@ -136,9 +136,12 @@ function runStatusUpdateJobs(): bool
             continue;
         }
 
-        $cron = array_filter(array_map('trim', explode(',', $account->cron)), function ($hour) {
-            return is_numeric($hour) && $hour !== '';
-        });
+        $cron = array_filter(
+            array_map('trim', explode(',', $account->cron)),
+            function (string $hour): bool {
+                return is_numeric($hour) && $hour !== '';
+            }
+        );
         if (empty($cron)) {
             logDebug("Skipping account: $accountName, cron field contains no valid hours.");
             continue;

--- a/root/lib/rss-lib.php
+++ b/root/lib/rss-lib.php
@@ -45,9 +45,12 @@ function outputRssFeed(string $accountName, string $accountOwner): void
         }
 
         // Sort statuses by creation date in descending order
-        usort($statuses, function ($a, $b) {
-            return strtotime($b->created_at) - strtotime($a->created_at);
-        });
+        usort(
+            $statuses,
+            function (object $a, object $b): int {
+                return strtotime($b->created_at) - strtotime($a->created_at);
+            }
+        );
     } else {
         // Retrieve account link
         $accountLink = AccountHandler::getAccountLink($accountOwner, $accountName);


### PR DESCRIPTION
## Summary
- add type hints for autoloader callback
- add type hints for cron logging and filter closure
- add typed closures in accounts helper
- type status sorting closure in RSS generator
- specify return type for `DatabaseHandler::single`

## Testing
- `php -l root/cron.php`
- `php -l root/app/helpers/accounts-helper.php`
- `php -l root/lib/rss-lib.php`
- `php -l root/classes/DatabaseHandler.php`
- `php -l root/autoload.php`


------
https://chatgpt.com/codex/tasks/task_e_68682e332c60832a92509627f8f0eb67