### PR TITLE
Add session timeout and user agent validation

### DIFF
--- a/root/config.php
+++ b/root/config.php
@@ -40,6 +40,9 @@ define('MAX_STATUSES', 8);
 // Maximum days to keep images. Should be over 360.
 define('IMG_AGE', 180);
 
+// Session timeout limit in seconds (default: 30 minutes)
+define('SESSION_TIMEOUT_LIMIT', 1800);
+
 // MySQL Database Connection Constants
 define('DB_HOST', 'localhost'); // Database host or server
 define('DB_USER', ''); // Database username

--- a/root/lib/load-lib.php
+++ b/root/lib/load-lib.php
@@ -23,7 +23,20 @@ if ($ip && UtilityHandler::isBlacklisted($ip)) {
     // Redirect to login page if the user is not logged in
     header('Location: login.php');
     die(1);
-} elseif (isset($_GET['page'])) {
+}
+
+// Enforce session timeout and user agent consistency
+$timeoutLimit = defined('SESSION_TIMEOUT_LIMIT') ? SESSION_TIMEOUT_LIMIT : 1800;
+$timeoutExceeded = isset($_SESSION['timeout']) && (time() - $_SESSION['timeout'] > $timeoutLimit);
+$userAgentChanged = isset($_SESSION['user_agent']) && $_SESSION['user_agent'] !== $_SERVER['HTTP_USER_AGENT'];
+if ($timeoutExceeded || $userAgentChanged) {
+    session_unset();
+    session_destroy();
+    header('Location: login.php');
+    die(1);
+}
+
+if (isset($_GET['page'])) {
     // Sanitize the page parameter to prevent XSS attacks and path traversal
     $page = filter_input(INPUT_GET, 'page', FILTER_SANITIZE_SPECIAL_CHARS);
     // Additional validation for page parameter to prevent path traversal


### PR DESCRIPTION
## Summary
- add configurable `SESSION_TIMEOUT_LIMIT` constant
- enforce session timeout and user agent consistency in `load-lib.php`

## Testing
- `php -l root/lib/load-lib.php`
- `php -l root/config.php`


------
https://chatgpt.com/codex/tasks/task_e_6868599f3a50832abcb4568950bfeba4