### PR TITLE
Safer directory permissions

### DIFF
--- a/docker/docker-config.php
+++ b/docker/docker-config.php
@@ -39,6 +39,9 @@ define('MAX_STATUSES', getenv('MAX_STATUSES'));
 // Maximum age of images in days before they are removed (should be over 360 days)
 define('IMG_AGE', getenv('IMG_AGE'));
 
+// Default permissions for creating directories
+define('DIR_MODE', 0755);
+
 // MySQL Database Connection Constants
 define('DB_HOST', getenv('DB_HOST'));
 define('DB_USER', getenv('DB_USER'));

--- a/root/classes/ApiHandler.php
+++ b/root/classes/ApiHandler.php
@@ -252,7 +252,8 @@ class ApiHandler // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespac
     $random_name = uniqid() . '.png';
     $image_path = __DIR__ . '/../public/images/' . $accountOwner . '/' . $accountName . '/' . $random_name;
 
-    if (!is_dir(dirname($image_path)) && !mkdir(dirname($image_path), 0777, true)) {
+    $dirMode = defined('DIR_MODE') ? DIR_MODE : 0755;
+    if (!is_dir(dirname($image_path)) && !mkdir(dirname($image_path), $dirMode, true)) {
         $error = "Failed to create directory for $accountName owned by $accountOwner.";
         ErrorHandler::logMessage($error, 'error');
         return ["error" => $error];

--- a/root/config.php
+++ b/root/config.php
@@ -40,6 +40,9 @@ define('MAX_STATUSES', 8);
 // Maximum days to keep images. Should be over 360.
 define('IMG_AGE', 180);
 
+// Default permissions for creating directories
+define('DIR_MODE', 0755);
+
 // MySQL Database Connection Constants
 define('DB_HOST', 'localhost'); // Database host or server
 define('DB_USER', ''); // Database username


### PR DESCRIPTION
## Summary
- add DIR_MODE constant for configuring directory permissions
- use DIR_MODE when creating image directories

## Testing
- `find root -name '*.php' -print0 | xargs -0 -I {} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_686859a0c278832a94a65074d0fb40c8