### PR TITLE
Escape dashboard messages in JS

### DIFF
--- a/root/classes/UtilityHandler.php
+++ b/root/classes/UtilityHandler.php
@@ -107,7 +107,7 @@ class UtilityHandler // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingName
     {
         if (isset($_SESSION['messages']) && count($_SESSION['messages']) > 0) {
             foreach ($_SESSION['messages'] as $message) {
-                echo "<script>showToast('" . htmlspecialchars($message) . "');</script>";
+                echo '<script>showToast(' . json_encode($message) . ');</script>';
             }
             unset($_SESSION['messages']);
         }


### PR DESCRIPTION
## Summary
- escape session messages before embedding into JavaScript in `displayAndClearMessages`

## Testing
- `php -l root/classes/UtilityHandler.php`
- `php -l root/public/login.php`
- `php -l root/public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_686859a75a38832a8aaf6305ba05938e