### PR TITLE
Improve session cookie security

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Version 2.0.0 introduces improvements such as dedicated classes for all database
 - **CSRF Protection:** All forms include CSRF tokens to prevent cross-site request forgery attacks.
 - **Input Validation:** User inputs are validated and sanitized to prevent SQL injection and XSS attacks.
 - **Session Management:** Secure session handling to prevent session fixation and hijacking.
+- **Cookie Security:** Session cookies are configured via `session_set_cookie_params()`
+  with `httponly`, `secure`, and `SameSite=Lax` flags for better protection.
 - **IP Blacklisting:** Monitors and blacklists suspicious IP addresses to prevent brute-force attacks.
 - **Efficient Database Queries:** Uses optimized SQL queries and indexing to ensure fast data retrieval.
 - **Modular Classes:** Core logic is organized into classes such as Database, UserHandler, AccountHandler, StatusHandler, UtilityHandler, and ErrorHandler for maintainability and scalability.

--- a/root/public/index.php
+++ b/root/public/index.php
@@ -14,6 +14,13 @@
  * @desc      Main dashboard file for the ChatGPT API Status Generator.
  */
 
+// Set secure session cookie parameters before starting the session
+$secureFlag = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
+session_set_cookie_params([
+    'httponly' => true,
+    'secure' => $secureFlag,
+    'samesite' => 'Lax'
+]);
 session_start();
 session_regenerate_id(true); // Regenerate session ID to prevent session fixation attacks
 

--- a/root/public/login.php
+++ b/root/public/login.php
@@ -9,6 +9,13 @@
  * License: MIT
  */
 
+// Set secure session cookie parameters before starting the session
+$secureFlag = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
+session_set_cookie_params([
+    'httponly' => true,
+    'secure' => $secureFlag,
+    'samesite' => 'Lax'
+]);
 session_start();
 require_once __DIR__ . '/../config.php';
 require_once __DIR__ . '/../autoload.php';


### PR DESCRIPTION
## Summary
- protect session cookies in `index.php` and `login.php`
- document secure cookie parameters in the README

## Testing
- `php -l root/public/login.php`
- `php -l root/public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_686859a92174832ab2c21556d3136d82