### PR TITLE
Fix RSS logging and account PK

### DIFF
--- a/root/install.sql
+++ b/root/install.sql
@@ -68,7 +68,7 @@ CREATE TABLE IF NOT EXISTS accounts (
     cron VARCHAR(255),
     days VARCHAR(255),
     platform VARCHAR(255) NOT NULL,
-    PRIMARY KEY (account)
+    PRIMARY KEY (username, account)
 );
 
 -- Ensure the accounts table has all the required columns (alter only if necessary)

--- a/root/public/feeds.php
+++ b/root/public/feeds.php
@@ -41,6 +41,9 @@ try {
     UtilityHandler::outputRssFeed($accountName, $accountOwner);
 } catch (Exception $e) {
     echo 'Error: ' . $e->getMessage();
-    ErrorHandler::logMessage("Error deleting old statuses: " . $e->getMessage(), 'error');
+    ErrorHandler::logMessage(
+        "RSS feed generation failed: " . $e->getMessage(),
+        'error'
+    );
     die(1);
 }


### PR DESCRIPTION
## Summary
- fix incorrect log message when generating RSS feeds
- enforce unique account names per user in install script

## Testing
- `php -l root/public/feeds.php`
- `php -l root/install.sql`

------
https://chatgpt.com/codex/tasks/task_e_68685e1b1ed4832aacc55d731ec1d0d2