### PR TITLE
Fix API call counter update in cron

### DIFF
--- a/root/cron.php
+++ b/root/cron.php
@@ -167,11 +167,15 @@ function runStatusUpdateJobs(): bool
                     }
 
                     if ($userInfo->used_api_calls < $userInfo->max_api_calls) {
-                        logDebug("User has remaining API calls. Incrementing used API calls.");
-                        $userInfo->used_api_calls += 1;
-                        UserHandler::updateUsedApiCalls($accountOwner, $userInfo->used_api_calls);
-                        ApiHandler::generateStatus($accountName, $accountOwner);
-                        logDebug("Status generated for account: $accountName.");
+                        logDebug("User has remaining API calls.");
+                        $statusResult = ApiHandler::generateStatus($accountName, $accountOwner);
+                        if (isset($statusResult['success'])) {
+                            logDebug("Status generated for account: $accountName.");
+                            $userInfo->used_api_calls += 1;
+                            UserHandler::updateUsedApiCalls($accountOwner, $userInfo->used_api_calls);
+                        } else {
+                            logDebug("Failed to generate status for account: $accountName.");
+                        }
                     } else {
                         logDebug("User has exceeded their API call limit.");
                     }


### PR DESCRIPTION
## Summary
- update `runStatusUpdateJobs()` to only increment API usage on success

## Testing
- `php -l root/cron.php`
- `php -l root/classes/ApiHandler.php`
- `php -l root/app/forms/home-forms.php`


------
https://chatgpt.com/codex/tasks/task_e_68685ff4c9f4832ab91e24d1e41ab2f9