### PR TITLE
Update DSN to use utf8mb4 charset

### DIFF
--- a/root/classes/DatabaseHandler.php
+++ b/root/classes/DatabaseHandler.php
@@ -37,7 +37,7 @@ class DatabaseHandler // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNam
 
         // Establish a new connection if none exists
         if (self::$dbh === null) {
-            $dsn = 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME;
+            $dsn = 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8mb4';
             $options = [
                         PDO::ATTR_PERSISTENT => true,
                         PDO::ATTR_ERRMODE    => PDO::ERRMODE_EXCEPTION,


### PR DESCRIPTION
## Summary
- ensure database connections default to UTF8MB4

## Testing
- `php -l root/classes/DatabaseHandler.php`

------
https://chatgpt.com/codex/tasks/task_e_68685feb93f0832a8aa36ee0a8f9dc1c