### PR TITLE
Make cron limits configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Install the project using the following steps:
 3. **Update Configuration:**
 
    - Open `root/config.php` and update the necessary variables, including MySQL database credentials.
+   - Optionally adjust `CRON_MAX_EXECUTION_TIME` and `CRON_MEMORY_LIMIT` to control how long the cron script runs and how much memory it can use.
 
 4. **Install Database:**
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       MAX_WIDTH: 720
       MAX_STATUSES: 30
       IMG_AGE: 360
+      CRON_MAX_EXECUTION_TIME: 0
+      CRON_MEMORY_LIMIT: 512M
       DB_HOST: 'db'
       DB_USER: 'root'
       DB_PASSWORD: ''

--- a/docker/docker-config.php
+++ b/docker/docker-config.php
@@ -42,6 +42,10 @@ define('IMG_AGE', getenv('IMG_AGE'));
 // Default permissions for creating directories
 define('DIR_MODE', 0755);
 
+// Cron runtime limits
+define('CRON_MAX_EXECUTION_TIME', getenv('CRON_MAX_EXECUTION_TIME') ?: 0);
+define('CRON_MEMORY_LIMIT', getenv('CRON_MEMORY_LIMIT') ?: '512M');
+
 // MySQL Database Connection Constants
 define('DB_HOST', getenv('DB_HOST'));
 define('DB_USER', getenv('DB_USER'));

--- a/root/config.php
+++ b/root/config.php
@@ -46,6 +46,10 @@ define('SESSION_TIMEOUT_LIMIT', 1800);
 // Default permissions for creating directories
 define('DIR_MODE', 0755);
 
+// Cron runtime limits
+define('CRON_MAX_EXECUTION_TIME', getenv('CRON_MAX_EXECUTION_TIME') !== false ? getenv('CRON_MAX_EXECUTION_TIME') : 0);
+define('CRON_MEMORY_LIMIT', getenv('CRON_MEMORY_LIMIT') !== false ? getenv('CRON_MEMORY_LIMIT') : '512M');
+
 // MySQL Database Connection Constants
 define('DB_HOST', 'localhost'); // Database host or server
 define('DB_USER', ''); // Database username

--- a/root/cron.php
+++ b/root/cron.php
@@ -11,11 +11,12 @@
  * License: MIT
  */
 
-ini_set('max_execution_time', 0); // Unlimited execution time
-ini_set('memory_limit', '512M'); // Adjust as needed
-
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/autoload.php';
+
+// Apply configured runtime limits after loading settings
+ini_set('max_execution_time', (string) (defined('CRON_MAX_EXECUTION_TIME') ? CRON_MAX_EXECUTION_TIME : 0));
+ini_set('memory_limit', defined('CRON_MEMORY_LIMIT') ? CRON_MEMORY_LIMIT : '512M');
 
 // Instantiate the ErrorHandler to register handlers
 new ErrorHandler();


### PR DESCRIPTION
## Summary
- allow configuring cron resource limits via `config.php`
- honor the new settings in `cron.php`
- expose settings in Docker files
- document new config options

## Testing
- `php -l root/cron.php`
- `php -l root/config.php`
- `php -l docker/docker-config.php`

------
https://chatgpt.com/codex/tasks/task_e_686860425e10832ab236f265c638e248