### PR TITLE
Handle non-2xx HTTP responses

### DIFF
--- a/root/classes/ApiHandler.php
+++ b/root/classes/ApiHandler.php
@@ -126,10 +126,15 @@ class ApiHandler // @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespac
     curl_setopt($ch, CURLOPT_TIMEOUT, 30);
 
     $response = curl_exec($ch);
+    $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     $error = curl_error($ch);
 
-    if ($response === false) {
-        $error = "Failed to make API request to $endpoint: $error";
+    if ($response === false || $statusCode < 200 || $statusCode >= 300) {
+        if ($response === false) {
+            $error = "Failed to make API request to $endpoint: $error";
+        } else {
+            $error = "API request to $endpoint returned HTTP status $statusCode";
+        }
         ErrorHandler::logMessage($error, 'error');
         curl_close($ch);
         return ["error" => $error];


### PR DESCRIPTION
## Summary
- catch HTTP errors after `curl_exec` in `ApiHandler`
- log and return the HTTP status code when non-2xx
- remove status code from returned error array

## Testing
- `php -l root/classes/ApiHandler.php`
- `php -l root/cron.php`


------
https://chatgpt.com/codex/tasks/task_e_6868602c44c0832a8b26df63e54254ef