### PR TITLE
Ensure password updates use session username

### DIFF
--- a/root/app/forms/info-forms.php
+++ b/root/app/forms/info-forms.php
@@ -20,7 +20,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     // Handle password change form submission
     if (isset($_POST["change_password"])) {
-        $username = $_POST['username'];
+        // Always use the currently logged in user for password updates
+        $username = $_SESSION['username'];
         $password = $_POST['password'];
         $password2 = $_POST['password2'];
 


### PR DESCRIPTION
## Summary
- change password update logic to rely solely on the current session user

## Testing
- `php -l root/app/forms/info-forms.php`
- `php -l root/app/pages/info.php`


------
https://chatgpt.com/codex/tasks/task_e_686e12f3c408832ab4cf1d03b3f883d5