### PR TITLE
Implement ErrorMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Version 2.0.0 introduces improvements such as dedicated classes for all database
   with `httponly`, `secure`, and `SameSite=Lax` flags for better protection.
 - **IP Blacklisting:** Monitors and blacklists suspicious IP addresses to prevent brute-force attacks.
 - **Efficient Database Queries:** Uses optimized SQL queries and indexing to ensure fast data retrieval.
-- **Modular Classes:** Core logic is organized into classes such as Database, UserHandler, AccountHandler, StatusHandler, UtilityHandler, and ErrorHandler for maintainability and scalability.
+- **Modular Classes:** Core logic is organized into classes such as Database, UserHandler, AccountHandler, StatusHandler, UtilityHandler, ErrorMiddleware, and ErrorHandler for maintainability and scalability.
 
 In upcoming updates I plan on optimizing the cron system with a task queue to prevent timeouts if there are many statuses to create. Also look at any other ways to secure the app.
 
@@ -46,8 +46,8 @@ In upcoming updates I plan on optimizing the cron system with a task queue to pr
 
 |     |      Feature      | Summary |
 | :-- | :---------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ⚙️  | **Architecture**  | <ul><li>Modular structure with dedicated classes: <code>DatabaseHandler</code>, <code>UserHandler</code>, <code>AccountHandler</code>, <code>StatusHandler</code>, <code>UtilityHandler</code>, <code>ErrorHandler</code>, and <code>ApiHandler</code> (see <code>root/classes/</code>).</li><li>Configuration centralized in <code>root/config.php</code>.</li><li>Autoloading handled by <code>root/autoload.php</code>.</li><li>Cron automation managed via <code>root/cron.php</code>.</li></ul> |
-| 🔩  | **Code Quality**  | <ul><li>Follows PHP best practices and design patterns.</li><li>Centralized database operations using PDO in <code>DatabaseHandler.php</code>.</li><li>Robust error handling via <code>ErrorHandler.php</code>.</li><li>Clean inline documentation throughout core files.</li></ul> |
+| ⚙️  | **Architecture**  | <ul><li>Modular structure with dedicated classes: <code>DatabaseHandler</code>, <code>UserHandler</code>, <code>AccountHandler</code>, <code>StatusHandler</code>, <code>UtilityHandler</code>, <code>ErrorMiddleware</code>, <code>ErrorHandler</code>, and <code>ApiHandler</code> (see <code>root/classes/</code>).</li><li>Configuration centralized in <code>root/config.php</code>.</li><li>Autoloading handled by <code>root/autoload.php</code>.</li><li>Cron automation managed via <code>root/cron.php</code>.</li></ul> |
+| 🔩  | **Code Quality**  | <ul><li>Follows PHP best practices and design patterns.</li><li>Centralized database operations using PDO in <code>DatabaseHandler.php</code>.</li><li>Robust error handling via <code>ErrorMiddleware.php</code> and <code>ErrorHandler.php</code>.</li><li>Clean inline documentation throughout core files.</li></ul> |
 | 📄  | **Documentation** | <ul><li>Includes install and usage steps.</li><li>Written in <code>PHP</code>, <code>SQL</code>, and <code>text</code> formats.</li><li>Simple onboarding for developers and admins.</li></ul> |
 | 🔌  | **Integrations**  | <ul><li>Posts to social platforms via <code>ApiHandler.php</code>.</li><li>Real-time RSS feed generation using <code>UtilityHandler::outputRssFeed()</code>.</li><li>Secure login and session control via <code>auth-lib.php</code>.</li></ul> |
 | 🧩  |  **Modularity**   | <ul><li>All logic encapsulated in single-purpose classes.</li><li>Autoloading supports scalability and clean structure.</li><li>Code reuse across handlers and views.</li></ul> |
@@ -66,6 +66,7 @@ In upcoming updates I plan on optimizing the cron system with a task queue to pr
     │   ├── config.php
     │   ├── Core
     │   │   ├── AuthMiddleware.php
+    │   │   ├── ErrorMiddleware.php
     │   │   ├── Controller.php
     │   │   ├── ErrorHandler.php
     │   │   ├── ApiHandler.php
@@ -147,7 +148,11 @@ In upcoming updates I plan on optimizing the cron system with a task queue to pr
 					</tr>
                                         <tr>
                                                 <td><b><a href='/root/classes/ErrorHandler.php'>ErrorHandler.php</a></b></td>
-                                                <td>- ErrorHandler ensures robust error management throughout the application by registering handlers for errors, exceptions, and shutdown events<br>- It transforms PHP errors into exceptions, logs uncaught exceptions, and manages critical shutdown errors, thereby enhancing the user experience with graceful error responses<br>- Additionally, it maintains a log of error messages, which aids in debugging and monitoring system health within the overall codebase architecture.</td>
+                                                <td>- ErrorHandler registers PHP handlers for errors, exceptions, and shutdown events<br>- It converts PHP errors into exceptions and logs them for later analysis</td>
+                                        </tr>
+                                        <tr>
+                                                <td><b><a href='/root/classes/ErrorMiddleware.php'>ErrorMiddleware.php</a></b></td>
+                                                <td>- ErrorMiddleware loads <code>ErrorHandler</code> at the start of each web request and catches uncaught exceptions around route dispatch<br>- This ensures graceful error responses and centralized logging during normal application flow</td>
                                         </tr>
                                         <tr>
                                                 <td><b><a href='/root/classes/ApiHandler.php'>ApiHandler.php</a></b></td>

--- a/root/app/Core/ErrorMiddleware.php
+++ b/root/app/Core/ErrorMiddleware.php
@@ -1,0 +1,36 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+/**
+ * Project: SocialRSS
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: ErrorMiddleware.php
+ * Description: AI Social Status Generator
+ */
+
+namespace App\Core;
+
+use Throwable;
+
+class ErrorMiddleware
+{
+    /**
+     * Register the error handlers and execute the callback.
+     *
+     * @param callable $callback Code to execute within the middleware.
+     * @return void
+     */
+    public static function handle(callable $callback): void
+    {
+        ErrorHandler::register();
+
+        try {
+            $callback();
+        } catch (Throwable $exception) {
+            ErrorHandler::handleException($exception);
+        }
+    }
+}

--- a/root/public/index.php
+++ b/root/public/index.php
@@ -13,6 +13,7 @@
  */
 
 use App\Core\Router;
+use App\Core\ErrorMiddleware;
 
 $secureFlag = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
 session_set_cookie_params([
@@ -26,5 +27,7 @@ session_regenerate_id(true);
 require_once '../config.php';
 require_once '../../vendor/autoload.php';
 
-$router = new Router();
-$router->dispatch($_SERVER['REQUEST_URI']);
+ErrorMiddleware::handle(function (): void {
+    $router = new Router();
+    $router->dispatch($_SERVER['REQUEST_URI']);
+});


### PR DESCRIPTION
## Summary
- add new `ErrorMiddleware` class to register error handlers and catch uncaught exceptions
- wrap request dispatch in `public/index.php` with the new middleware
- document `ErrorMiddleware` throughout the README

## Testing
- `php -l root/app/Core/ErrorMiddleware.php`
- `php -l root/public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_686e1d1c4210832abc2ef5ca39eccf37