### PR TITLE
Add CSRF check to login

### DIFF
--- a/root/app/Controllers/AuthController.php
+++ b/root/app/Controllers/AuthController.php
@@ -33,6 +33,14 @@ class AuthController
         }
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {
+                $error = 'Invalid CSRF token. Please try again.';
+                ErrorMiddleware::logMessage($error);
+                $_SESSION['messages'][] = $error;
+                include __DIR__ . '/../Views/login.php';
+                return;
+            }
+
         $username = isset($_POST['username']) ? $_POST['username'] : null;
         $password = isset($_POST['password']) ? $_POST['password'] : null;
         $userInfo = UserHandler::getUserInfo($username);


### PR DESCRIPTION
## Summary
- verify CSRF token in `AuthController` before authenticating

## Testing
- `php -l root/app/Controllers/AuthController.php`

------
https://chatgpt.com/codex/tasks/task_e_686e4e3625b0832a8686fc998467a982