### PR TITLE
Set admin session flag on login

### DIFF
--- a/root/app/Controllers/AuthController.php
+++ b/root/app/Controllers/AuthController.php
@@ -24,6 +24,7 @@ class AuthController
     {
         if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true) {
             if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['logout'])) {
+                unset($_SESSION['is_admin']);
                 session_destroy();
                 header('Location: /login');
                 exit();
@@ -43,6 +44,7 @@ class AuthController
                 $_SESSION['username'] = $username;
                 $_SESSION['user_agent'] = $_SERVER['HTTP_USER_AGENT'];
                 $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+                $_SESSION['is_admin'] = $userInfo->admin;
                 session_regenerate_id(true);
                 header('Location: /');
                 exit();


### PR DESCRIPTION
## Summary
- set `$_SESSION['is_admin']` after verifying credentials
- clear the admin flag when logging out

## Testing
- `php -l root/app/Controllers/AuthController.php`
- `find root -name '*.php' -print0 | xargs -0 -I {} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_686e4e867820832a94c93689486a7dd5