### PR TITLE
Fix views to use controller-provided data

### DIFF
--- a/root/app/Controllers/AccountsController.php
+++ b/root/app/Controllers/AccountsController.php
@@ -100,7 +100,15 @@ class AccountsController extends Controller
             }
         }
 
-        self::render('accounts');
+        $daysOptions = self::generateDaysOptions();
+        $cronOptions = self::generateCronOptions();
+        $accountList = self::generateAccountList();
+
+        self::render('accounts', [
+            'daysOptions' => $daysOptions,
+            'cronOptions' => $cronOptions,
+            'accountList' => $accountList,
+        ]);
     }
 
     public static function generateDaysOptions(): string

--- a/root/app/Controllers/HomeController.php
+++ b/root/app/Controllers/HomeController.php
@@ -77,7 +77,41 @@ class HomeController extends Controller
             }
         }
 
-        self::render('home');
+        $accountOwner = $_SESSION['username'];
+        $accounts = \App\Models\AccountHandler::getAllUserAccts($accountOwner);
+        $accountsData = [];
+        foreach ($accounts as $account) {
+            $name = $account->account;
+            $acctInfo = \App\Models\AccountHandler::getAcctInfo($accountOwner, $name);
+            $statuses = StatusHandler::getStatusInfo($accountOwner, $name);
+            $statusList = [];
+            foreach ($statuses as $status) {
+                $statusList[] = [
+                    'status' => $status->status,
+                    'status_image' => $status->status_image,
+                    'created_at' => $status->created_at,
+                    'id' => $status->id,
+                    'share_button' => self::shareButton(
+                        $status->status,
+                        $status->status_image,
+                        $accountOwner,
+                        $name,
+                        $status->id
+                    ),
+                ];
+            }
+            $accountsData[] = [
+                'name' => $name,
+                'info' => $acctInfo,
+                'feedUrl' => "/feeds/{$accountOwner}/{$name}",
+                'statuses' => $statusList,
+            ];
+        }
+
+        self::render('home', [
+            'accountOwner' => $accountOwner,
+            'accountsData' => $accountsData,
+        ]);
     }
 
     public static function shareButton(string $statusText, string $imagePath, string $accountOwner, string $accountName, int $statusId): string

--- a/root/app/Controllers/InfoController.php
+++ b/root/app/Controllers/InfoController.php
@@ -76,7 +76,13 @@ class InfoController extends Controller
             }
         }
 
-        self::render('info');
+        $profileData = self::generateProfileDataAttributes($_SESSION['username']);
+        $systemMsg = self::buildSystemMessage($_SESSION['username']);
+
+        self::render('info', [
+            'profileData' => $profileData,
+            'systemMsg' => $systemMsg,
+        ]);
     }
 
     public static function generateProfileDataAttributes(string $username): string

--- a/root/app/Controllers/UsersController.php
+++ b/root/app/Controllers/UsersController.php
@@ -117,7 +117,11 @@ class UsersController extends Controller
             }
         }
 
-        self::render('users');
+        $userList = self::generateUserList();
+
+        self::render('users', [
+            'userList' => $userList,
+        ]);
     }
 
     public static function generateUserList(): string

--- a/root/app/Views/accounts.php
+++ b/root/app/Views/accounts.php
@@ -12,7 +12,7 @@
  * Description: AI Social Status Generator
  */
 
-use App\Controllers\AccountsController;
+
 
 require 'layouts/header.php';
 ?>
@@ -46,14 +46,12 @@ require 'layouts/header.php';
                 <!-- Days selection dropdown (multiple) -->
                 <label for="days">Days:</label>
                 <select class="form-select" name="days[]" id="days" multiple required>
-                    <?php
- echo AccountsController::generateDaysOptions(); ?>
+                    <?php echo $daysOptions; ?>
                 </select>
                 <!-- Post schedule selection dropdown (multiple) -->
                 <label for="cron">Post Schedule:</label>
                 <select class="form-select" name="cron[]" id="cron" multiple required>
-                    <?php
- echo AccountsController::generateCronOptions(); ?>
+                    <?php echo $cronOptions; ?>
                 </select>
                 <!-- Hashtags inclusion dropdown -->
                 <label for="hashtags">Include Hashtags:</label>
@@ -72,8 +70,7 @@ require 'layouts/header.php';
                 <h3 class="account-name card-title">Account List</h3>
             </div>
             <div class="columns">
-                <?php
- echo AccountsController::generateAccountList(); ?>
+                <?php echo $accountList; ?>
             </div>
         </div>
     </div>

--- a/root/app/Views/home.php
+++ b/root/app/Views/home.php
@@ -12,38 +12,27 @@
  * Description: AI Social Status Generator
  */
 
-use App\Controllers\HomeController;
-use App\Models\AccountHandler;
-use App\Models\StatusHandler;
+
 
 require 'layouts/header.php';
 ?>
 
 <main class="container">
     <?php
+    $accountOwnerEsc = htmlspecialchars($accountOwner, ENT_QUOTES);
 
-    // Retrieve the account owner from the session and fetch all user accounts
-    $accountOwner = htmlspecialchars($_SESSION['username'], ENT_QUOTES);
-    $accounts = AccountHandler::getAllUserAccts($accountOwner);
-
-    // Display a message if no accounts are found
-    if (empty($accounts)) {
+    if (empty($accountsData)) {
         echo '<div id="no-account" class="empty"><p class="empty-title">Please set up an account!</p></div>';
-        return;
-    }
-
-    // Iterate through each account and display its statuses
-    foreach ($accounts as $index => $account) : ?>
-        <?php
-
-        $accountName = htmlspecialchars($account->account, ENT_QUOTES);
-        $acctInfo = AccountHandler::getAcctInfo($accountOwner, $accountName);
-        $statuses = StatusHandler::getStatusInfo($accountOwner, $accountName);
-        $feedUrl = htmlspecialchars("/feeds/{$accountOwner}/{$accountName}", ENT_QUOTES);
-        $isOpen = $index === 0 ? 'flex' : 'none';
-        $buttonIcon = $index === 0 ? 'icon-arrow-up' : 'icon-arrow-right';
-        $accountActionDisplay = $index === 0 ? 'flex' : 'none';
-        ?>
+    } else {
+        foreach ($accountsData as $index => $acct) :
+            $accountName = htmlspecialchars($acct['name'], ENT_QUOTES);
+            $acctInfo = $acct['info'];
+            $statuses = $acct['statuses'];
+            $feedUrl = htmlspecialchars($acct['feedUrl'], ENT_QUOTES);
+            $isOpen = $index === 0 ? 'flex' : 'none';
+            $buttonIcon = $index === 0 ? 'icon-arrow-up' : 'icon-arrow-right';
+            $accountActionDisplay = $index === 0 ? 'flex' : 'none';
+    ?>
 
         <div class="status-container card">
             <div class="status-header card-header">
@@ -59,32 +48,24 @@ require 'layouts/header.php';
  if (!empty($statuses)) : ?>
                 <div class="status-content columns" style="display: <?php
  echo $isOpen ?>;">
-                    <?php
- foreach ($statuses as $status) : ?>
-                        <?php
- if (!empty($status->status)) : ?>
+            <?php foreach ($statuses as $status) : ?>
+                        <?php if (!empty($status['status'])) : ?>
                             <div class="status-wrapper column col-3 col-md-4 col-sm-6 col-xs-12">
                                 <div class="status-item card">
-                                    <img src="<?php
- echo htmlspecialchars($status->status_image ? "images/{$accountOwner}/{$accountName}/{$status->status_image}" : 'assets/images/default.png') ?>" class="status-image img-responsive" loading="lazy">
+                                    <img src="<?php echo htmlspecialchars($status['status_image'] ? "images/{$accountOwnerEsc}/{$accountName}/{$status['status_image']}" : 'assets/images/default.png'); ?>" class="status-image img-responsive" loading="lazy">
                                     <p class="status-text">
-                                        <?php
- echo htmlspecialchars($status->status) ?>
+                                        <?php echo htmlspecialchars($status['status']); ?>
                                     </p>
                                     <div class="status-meta">
                                         <strong class="status-info">
-                                            <?php
- echo date('m/d/y g:ia', strtotime($status->created_at)) ?>
+                                            <?php echo date('m/d/y g:ia', strtotime($status['created_at'])); ?>
                                         </strong>
-                                        <?php
- echo HomeController::shareButton($status->status, $status->status_image, $accountOwner, $accountName, $status->id); ?>
+                                        <?php echo $status['share_button']; ?>
                                     </div>
                                 </div>
                             </div>
-                        <?php
- endif; ?>
-                    <?php
- endforeach; ?>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
                 </div>
             <?php
  else : ?>
@@ -101,8 +82,7 @@ require 'layouts/header.php';
                 <form class="account-action-form" action="/home" method="POST">
                     <input type="hidden" name="account" value="<?php
  echo htmlspecialchars($accountName, ENT_QUOTES) ?>">
-                    <input type="hidden" name="username" value="<?php
- echo htmlspecialchars($accountOwner, ENT_QUOTES) ?>">
+                    <input type="hidden" name="username" value="<?php echo $accountOwnerEsc ?>">
                     <input type="hidden" name="csrf_token" value="<?php
  echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES) ?>">
                     <button type="submit" class="generate-status-button btn btn-success" name="generate_status">Generate Status</button>
@@ -110,7 +90,9 @@ require 'layouts/header.php';
             </div>
         </div>
     <?php
- endforeach; ?>
+        endforeach;
+    }
+    ?>
 </main>
 
 <script>

--- a/root/app/Views/info.php
+++ b/root/app/Views/info.php
@@ -12,7 +12,7 @@
  * Description: AI Social Status Generator
  */
 
-use App\Controllers\InfoController;
+
 ?>
 
 <?php
@@ -25,8 +25,7 @@ use App\Controllers\InfoController;
             <div class="info-header card-header">
                 <h3 class="info-name card-title">Your Profile</h3>
             </div>
-            <form class="form-group columns" method="post" id="update-profile-form" <?php
- echo InfoController::generateProfileDataAttributes($_SESSION['username']); ?>>
+            <form class="form-group columns" method="post" id="update-profile-form" <?php echo $profileData; ?>>
                 <div class="column col-6 col-md-6 col-sm-12">
                     <!-- Who input field -->
                     <label for="who">Who:</label>
@@ -82,8 +81,7 @@ use App\Controllers\InfoController;
                     <h3 class="card-title">System Message</h3>
                 </div>
                 <div class="card-body">
-                    <p><?php
- echo InfoController::buildSystemMessage($_SESSION['username']); ?></p>
+                    <p><?php echo $systemMsg; ?></p>
                 </div>
             </div>
         </div>

--- a/root/app/Views/users.php
+++ b/root/app/Views/users.php
@@ -12,7 +12,7 @@
  * Description: AI Social Status Generator
  */
 
-use App\Controllers\UsersController;
+
 
 require 'layouts/header.php';
 ?>
@@ -80,8 +80,7 @@ require 'layouts/header.php';
                 <h3 class="account-name card-title">User List</h3>
             </div>
             <div class="columns">
-                <?php
- echo UsersController::generateUserList(); ?>
+                <?php echo $userList; ?>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- stop importing controllers inside view templates
- move data generation to controllers and pass values to views
- update views to consume variables instead of calling the controllers directly

## Testing
- `php -l root/app/Controllers/AccountsController.php`
- `php -l root/app/Controllers/InfoController.php`
- `php -l root/app/Controllers/HomeController.php`
- `php -l root/app/Controllers/UsersController.php`
- `php -l root/app/Views/home.php`
- `php -l root/app/Views/accounts.php`
- `php -l root/app/Views/info.php`
- `php -l root/app/Views/users.php`

------
https://chatgpt.com/codex/tasks/task_e_686e5b053df4832abb0adb994f389f86