### PR TITLE
Add custom 404 view

### DIFF
--- a/root/app/Views/404.php
+++ b/root/app/Views/404.php
@@ -1,0 +1,24 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+
+/**
+ * Project: SocialRSS
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: 404.php
+ * Description: Page not found view
+ */
+
+require 'layouts/header.php';
+?>
+
+<main class="container">
+    <div class="empty">
+        <p class="empty-title">Page not found</p>
+    </div>
+</main>
+
+<?php require 'layouts/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add a 404 view with header and footer layout
- router already points to this file when no route is found

## Testing
- `php -l root/app/Views/404.php`
- `php -l root/app/Core/Router.php`

------
https://chatgpt.com/codex/tasks/task_e_686e81888a70832a8b1ba9a0a099adb1