### PR TITLE
Fix image directory references

### DIFF
--- a/root/app/Controllers/FeedController.php
+++ b/root/app/Controllers/FeedController.php
@@ -115,7 +115,8 @@ class FeedController extends Controller
             // Include image enclosure if available
             if (!empty($status->status_image)) {
                 $imageUrl = DOMAIN . "/images/" . htmlspecialchars($accountOwner) . "/" . htmlspecialchars($status->account) . "/" . htmlspecialchars($status->status_image);
-                $imageFilePath = __DIR__ . '/../public/images/' . htmlspecialchars($accountOwner) . '/' . htmlspecialchars($status->account) . '/' . htmlspecialchars($status->status_image);
+                // Images are stored under root/public/images/<owner>/<account>/
+                $imageFilePath = __DIR__ . '/../../public/images/' . htmlspecialchars($accountOwner) . '/' . htmlspecialchars($status->account) . '/' . htmlspecialchars($status->status_image);
                 $imageFileSize = file_exists($imageFilePath) ? filesize($imageFilePath) : 0;
                 $enclosureTag = '<enclosure url="' . $imageUrl . '" length="' . $imageFileSize . '" type="image/png" />' . PHP_EOL;
             }

--- a/root/app/Controllers/StatusController.php
+++ b/root/app/Controllers/StatusController.php
@@ -283,7 +283,8 @@ class StatusController
 
     $image_url = $response['data'][0]['url'];
     $random_name = uniqid() . '.png';
-    $image_path = __DIR__ . '/../public/images/' . $accountOwner . '/' . $accountName . '/' . $random_name;
+    // Save under root/public/images/<owner>/<account>/
+    $image_path = __DIR__ . '/../../public/images/' . $accountOwner . '/' . $accountName . '/' . $random_name;
 
     $dirMode = defined('DIR_MODE') ? DIR_MODE : 0755;
     if (!is_dir(dirname($image_path)) && !mkdir(dirname($image_path), $dirMode, true)) {


### PR DESCRIPTION
## Summary
- store generated images under root/public/images
- keep FeedController in sync with updated image path

## Testing
- `php -l root/app/Controllers/StatusController.php`
- `php -l root/app/Controllers/FeedController.php`


------
https://chatgpt.com/codex/tasks/task_e_686e819e39e0832aa52101b0885a5935