### PR TITLE
Fix feed route auth order

### DIFF
--- a/root/app/Core/Router.php
+++ b/root/app/Core/Router.php
@@ -22,13 +22,13 @@ class Router
     {
         $route = strtok($uri, '?');
 
-        if ($route !== '/login') {
-            AuthMiddleware::check();
-        }
-
         if (preg_match('#^/feeds(?:/[^/]+/[^/]+)?$#', $route)) {
             \App\Controllers\FeedController::handleRequest();
             return;
+        }
+
+        if ($route !== '/login') {
+            AuthMiddleware::check();
         }
 
         switch ($route) {


### PR DESCRIPTION
## Summary
- allow unauthenticated feed access
- call auth middleware after feed check

## Testing
- `php -l root/app/Core/Router.php`
- `find root -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_686e81a7de28832aada9f64a8196c4f6