### PR TITLE
Add config validation logic to docker config

### DIFF
--- a/docker/docker-config.php
+++ b/docker/docker-config.php
@@ -68,3 +68,21 @@ define('SMTP_FROM_NAME', getenv('SMTP_FROM_NAME'));
 if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 }
+
+// Validate required configuration constants
+$required_constants = ['DB_HOST', 'DB_USER', 'DB_NAME', 'API_KEY'];
+$missing_config = [];
+
+foreach ($required_constants as $constant) {
+    if (!defined($constant) || empty(constant($constant))) {
+        $missing_config[] = $constant;
+    }
+}
+
+if (!empty($missing_config)) {
+    error_log("Missing required configuration: " . implode(', ', $missing_config));
+    if (php_sapi_name() !== 'cli') {
+        http_response_code(500);
+        die("Configuration error: Missing required settings. Please check server logs.");
+    }
+}


### PR DESCRIPTION
## Summary
- ensure environment variables are validated in docker config

## Testing
- `php -l docker/docker-config.php`
- `php -l root/config.php`
- `composer install --no-interaction` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e89a1d304832ab926532f8ba25f54