### PR TITLE
Add DB init entrypoint

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,8 @@ WORKDIR /var/www/
 COPY root/ /var/www/
 # Bring in docker specific configuration
 COPY docker/docker-config.php /var/www/docker-config.php
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Update Apache configuration to set the document root
 RUN sed -i 's|/var/www/html|/var/www/public|g' /etc/apache2/sites-available/000-default.conf
@@ -30,8 +32,6 @@ RUN echo "0 12 1 * * php /var/www/cron.php reset_usage" >> /etc/crontab && \
     echo "0 12 * * * php /var/www/cron.php cleanup" >> /etc/crontab && \
     crontab /etc/crontab
 
-# Remove unnecessary install file
-RUN rm -f /var/www/public/install.php
 
 # Delete old config.php and rename docker-config.php to config.php
 RUN rm -f /var/www/config.php && mv /var/www/docker-config.php /var/www/config.php
@@ -39,5 +39,5 @@ RUN rm -f /var/www/config.php && mv /var/www/docker-config.php /var/www/config.p
 # Expose port 80
 EXPOSE 80
 
-# Start cron and Apache
-CMD service cron start && apache2-foreground
+# Start application through entrypoint script
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+# Wait for MariaDB service to be available
+until mysqladmin ping -h "${DB_HOST}" -u "${DB_USER}" --password="${DB_PASSWORD}" --silent; do
+  echo "Waiting for MariaDB..."
+  sleep 2
+done
+
+# Check if a known table exists
+TABLE_EXISTS=$(mysql -h "$DB_HOST" -u "$DB_USER" --password="$DB_PASSWORD" -D "$DB_NAME" -sse "SHOW TABLES LIKE 'users';")
+if [ -z "$TABLE_EXISTS" ]; then
+  echo "Importing initial database..."
+  mysql -h "$DB_HOST" -u "$DB_USER" --password="$DB_PASSWORD" "$DB_NAME" < /var/www/install.sql
+fi
+
+# Remove install script if initialization succeeded
+if mysql -h "$DB_HOST" -u "$DB_USER" --password="$DB_PASSWORD" -D "$DB_NAME" -sse "SHOW TABLES LIKE 'users';" | grep -q users; then
+  rm -f /var/www/public/install.php
+fi
+
+# Start cron and Apache
+service cron start
+exec apache2-foreground


### PR DESCRIPTION
## Summary
- add entrypoint that waits for MariaDB and imports `install.sql`
- copy entrypoint in Dockerfile and start container through it
- remove build-time deletion of `install.php`

## Testing
- `composer install --no-interaction` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e89b76188832a972da553724d35f1