### PR TITLE
Allow empty root password via compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ docker compose up
 
 This launches an Apache web server and MariaDB instance with configuration values taken from the compose file. Adjust the environment variables there to set API keys and database credentials.
 
+The `db` service allows an empty MariaDB root password by setting `MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: '1'`. If you want a password instead, set `MYSQL_ROOT_PASSWORD` and update `DB_PASSWORD` in the `web` service.
+
 ---
 
 ## Changelog

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     image: mariadb:latest
     environment:
       MYSQL_ROOT_PASSWORD: ''
+      MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: '1'
       MYSQL_DATABASE: 'vsocialai'
     volumes:
       - db_data:/var/lib/mysql


### PR DESCRIPTION
## Summary
- permit empty root password by adding `MARIADB_ALLOW_EMPTY_ROOT_PASSWORD` to the DB service
- document the new variable and password guidance in the Docker section of the README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e89bef648832ab69e72bed26817df