### PR TITLE
Add calendar overview on accounts page

### DIFF
--- a/root/app/Views/accounts.php
+++ b/root/app/Views/accounts.php
@@ -73,7 +73,11 @@ require 'layouts/header.php';
                 <?php echo $accountList; ?>
             </div>
         </div>
-    </div>
+</div>
+    <section class="calendar-overview">
+        <h3>Calendar Overview</h3>
+        <?php echo $calendarOverview; ?>
+    </section>
 </main>
 
 <script>

--- a/root/public/assets/css/styles.css
+++ b/root/public/assets/css/styles.css
@@ -452,6 +452,46 @@ footer p {
 }
 
 /* ================================================
+   CALENDAR OVERVIEW STYLES
+================================================ */
+
+.calendar-overview {
+  margin-top: 40px;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 10px;
+}
+
+.calendar-day {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: #fff;
+  padding: 5px;
+}
+
+.calendar-day h4 {
+  margin: 0 0 5px;
+  text-align: center;
+}
+
+.calendar-slot {
+  border-top: 1px solid #eee;
+  padding: 4px;
+  min-height: 40px;
+}
+.calendar-slot:first-of-type {
+  border-top: none;
+}
+.calendar-slot ul {
+  margin: 0;
+  padding-left: 16px;
+  list-style-type: disc;
+}
+
+/* ================================================
    MOBILE RESPONSIVE STYLES
 ================================================ */
 


### PR DESCRIPTION
## Summary
- aggregate account schedules into a calendar view
- expose calendar data in AccountsController
- render calendar grid on the accounts page
- style the calendar grid layout

## Testing
- `php -l root/app/Controllers/AccountsController.php`
- `php -l root/app/Views/accounts.php`
- `composer validate --no-check-all`

------
https://chatgpt.com/codex/tasks/task_e_68727ed9a140832a8a086b1626551642