### PR TITLE
Fix calendar overview generation

### DIFF
--- a/root/app/Controllers/AccountsController.php
+++ b/root/app/Controllers/AccountsController.php
@@ -116,7 +116,7 @@ class AccountsController extends Controller
     /**
      * Generate a calendar overview of scheduled posts grouped by day and time slot.
      */
-    $overview = self::initializeOverview($daysOfWeek);
+    public static function generateCalendarOverview(): string
     {
         $username = $_SESSION['username'];
         $accounts = User::getAllUserAccts($username);


### PR DESCRIPTION
## Summary
- fix `generateCalendarOverview` method in `AccountsController`

## Testing
- `php -l root/app/Controllers/AccountsController.php`
- `for f in root/app/Controllers/*.php; do php -l $f; done`
- `for f in root/app/Core/*.php; do php -l $f; done`


------
https://chatgpt.com/codex/tasks/task_e_687514b993d0832aa8b247f235c99275