### PR TITLE
Add cron job queue support

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Install the project using the following steps:
 3. **Update Configuration:**
 
    - Open `root/config.php` and update the necessary variables, including MySQL database credentials.
-   - Optionally adjust `CRON_MAX_EXECUTION_TIME` and `CRON_MEMORY_LIMIT` to control how long the cron script runs and how much memory it can use.
+   - Optionally adjust `CRON_MAX_EXECUTION_TIME`, `CRON_MEMORY_LIMIT`, and `CRON_QUEUE_LIMIT` to control how long the cron script runs, how much memory it can use, and how many queued jobs run each invocation.
 
 4. **Install Database:**
 
@@ -326,7 +326,9 @@ Install the project using the following steps:
      /usr/bin/php /PATH-TO-CRON.PHP/cron.php clear_list 0 12 * * *
      /usr/bin/php /PATH-TO-CRON.PHP/cron.php run_status 0 * * * *
      /usr/bin/php /PATH-TO-CRON.PHP/cron.php cleanup 0 12 * * *
-     ```
+     /usr/bin/php /PATH-TO-CRON.PHP/cron.php fill_query 0 * * * *
+     /usr/bin/php /PATH-TO-CRON.PHP/cron.php run_query * * * * *
+    ```
    - Replace `/PATH-TO-CRON.PHP/` with the actual path to your `cron.php` file.
 
 ### 🤖 Usage

--- a/root/config.php
+++ b/root/config.php
@@ -51,6 +51,7 @@ define('DIR_MODE', 0755);
 // Cron runtime limits
 define('CRON_MAX_EXECUTION_TIME', getenv('CRON_MAX_EXECUTION_TIME') !== false ? getenv('CRON_MAX_EXECUTION_TIME') : 0);
 define('CRON_MEMORY_LIMIT', getenv('CRON_MEMORY_LIMIT') !== false ? getenv('CRON_MEMORY_LIMIT') : '512M');
+define('CRON_QUEUE_LIMIT', getenv('CRON_QUEUE_LIMIT') !== false ? (int) getenv('CRON_QUEUE_LIMIT') : 10);
 
 // MySQL Database Connection Constants
 define('DB_HOST', 'localhost'); // Database host or server

--- a/root/install.sql
+++ b/root/install.sql
@@ -58,6 +58,35 @@ IF @index_exists = 0 THEN
     CREATE INDEX created_at ON status_updates (created_at);
 END IF;
 
+-- Create the status_jobs table if it doesn't exist
+CREATE TABLE IF NOT EXISTS status_jobs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(255) NOT NULL,
+    account VARCHAR(255) NOT NULL,
+    run_at DATETIME NOT NULL,
+    status ENUM('pending','completed') DEFAULT 'pending',
+    payload TEXT
+);
+
+-- Ensure the status_jobs table has all the required columns (alter only if necessary)
+ALTER TABLE status_jobs
+ADD COLUMN IF NOT EXISTS username VARCHAR(255) NOT NULL,
+ADD COLUMN IF NOT EXISTS account VARCHAR(255) NOT NULL,
+ADD COLUMN IF NOT EXISTS run_at DATETIME NOT NULL,
+ADD COLUMN IF NOT EXISTS status ENUM('pending','completed') DEFAULT 'pending',
+ADD COLUMN IF NOT EXISTS payload TEXT;
+
+-- Ensure indexes on status_jobs table
+SET @index_exists = (SELECT COUNT(1) IndexIsThere FROM INFORMATION_SCHEMA.STATISTICS WHERE table_schema=DATABASE() AND table_name='status_jobs' AND index_name='username_idx');
+IF @index_exists = 0 THEN
+    CREATE INDEX username_idx ON status_jobs (username);
+END IF;
+
+SET @index_exists = (SELECT COUNT(1) IndexIsThere FROM INFORMATION_SCHEMA.STATISTICS WHERE table_schema=DATABASE() AND table_name='status_jobs' AND index_name='run_at_idx');
+IF @index_exists = 0 THEN
+    CREATE INDEX run_at_idx ON status_jobs (run_at);
+END IF;
+
 -- Create accounts table if it doesn’t exist
 CREATE TABLE IF NOT EXISTS accounts (
     account VARCHAR(255) NOT NULL,


### PR DESCRIPTION
## Summary
- add `status_jobs` table to installer
- support queued jobs in cron with `fill_query` and `run_query`
- set `CRON_QUEUE_LIMIT` in config
- document new cron commands

## Testing
- `php -l root/cron.php`
- `php -l root/config.php`


------
https://chatgpt.com/codex/tasks/task_e_687c420648fc832ab86fe3b2f34aa7e1