### PR TITLE
Implement job queue locking and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,17 +324,18 @@ Install the project using the following steps:
      ```sh
      /usr/bin/php /PATH-TO-CRON.PHP/cron.php reset_usage 0 12 1 * *
      /usr/bin/php /PATH-TO-CRON.PHP/cron.php clear_list 0 12 * * *
-     /usr/bin/php /PATH-TO-CRON.PHP/cron.php run_status 0 * * * *
-     /usr/bin/php /PATH-TO-CRON.PHP/cron.php cleanup 0 12 * * *
-     /usr/bin/php /PATH-TO-CRON.PHP/cron.php fill_query 0 * * * *
-     /usr/bin/php /PATH-TO-CRON.PHP/cron.php run_query * * * * *
+    /usr/bin/php /PATH-TO-CRON.PHP/cron.php cleanup 0 12 * * *
+    /usr/bin/php /PATH-TO-CRON.PHP/cron.php fill_query 0 * * * *
+    /usr/bin/php /PATH-TO-CRON.PHP/cron.php run_query * * * * *
      ```
    - Replace `/PATH-TO-CRON.PHP/` with the actual path to your `cron.php` file.
-   - `fill_query` populates the `status_jobs` queue with the next 24 hours of
-     scheduled posts. Run it hourly so the queue stays fresh.
-   - `run_query` processes queued jobs and marks them as completed. It will run
-     up to `CRON_QUEUE_LIMIT` jobs per invocation, so schedule this command every
-     minute for timely posting.
+  - `fill_query` populates the `status_jobs` queue with the next 24 hours of
+    scheduled posts. Run it hourly so the queue stays fresh.
+  - `run_query` processes queued jobs and marks them as completed. It will run
+    up to `CRON_QUEUE_LIMIT` jobs per invocation, so schedule this command every
+    minute for timely posting.
+  - The previous `run_status` task is no longer needed; `run_query` handles
+    posting from the queue.
 
 ### Queue Table
 

--- a/root/install.sql
+++ b/root/install.sql
@@ -64,7 +64,7 @@ CREATE TABLE IF NOT EXISTS status_jobs (
     username VARCHAR(255) NOT NULL,
     account VARCHAR(255) NOT NULL,
     run_at DATETIME NOT NULL,
-    status ENUM('pending','completed') DEFAULT 'pending',
+    status ENUM('pending','processing','completed') DEFAULT 'pending',
     payload TEXT
 );
 
@@ -73,7 +73,7 @@ ALTER TABLE status_jobs
 ADD COLUMN IF NOT EXISTS username VARCHAR(255) NOT NULL,
 ADD COLUMN IF NOT EXISTS account VARCHAR(255) NOT NULL,
 ADD COLUMN IF NOT EXISTS run_at DATETIME NOT NULL,
-ADD COLUMN IF NOT EXISTS status ENUM('pending','completed') DEFAULT 'pending',
+ADD COLUMN IF NOT EXISTS status ENUM('pending','processing','completed') DEFAULT 'pending',
 ADD COLUMN IF NOT EXISTS payload TEXT;
 
 -- Ensure indexes on status_jobs table


### PR DESCRIPTION
## Summary
- add `processing` status to `status_jobs`
- implement job queue helpers for claiming and finishing jobs
- prevent duplicate cron processing
- document updated queue cron tasks and remove old run_status entry

## Testing
- `php -l root/app/Models/JobQueue.php`
- `php -l root/cron.php`
- `find root -name '*.php' | xargs -I {} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_687c4ba93a8c832a8222ce2143ad2f36