### PR TITLE
Implement job queue and cron improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ VII. [ License](#-license)
 
 ## Overview
 
-v-chatgpt-social-status-feeds is a modular PHP application for managing, scheduling, and distributing social media status updates. It features user authentication, account management, status scheduling, and real-time RSS feeds, all with a focus on security and extensibility. Built for social media managers and developers, it streamlines multi-account status posting and automation.
+v-chatgpt-social-status-feeds is a modular PHP application for managing, scheduling, and distributing social media status updates. It features user authentication, account management, status scheduling, and real-time RSS feeds, all with a focus on security and extensibility. Scheduled posts are placed in a MySQL-backed queue and processed asynchronously by the cron script. Built for social media managers and developers, it streamlines multi-account status posting and automation.
 
 All PHP source files live inside the `root` directory. The code uses a lightweight MVC approach with controllers, models, and views organized under `root/app`. Bootstrapping is handled by `root/autoload.php` and `root/config.php`. For an easy local setup, the repository includes a `docker` folder containing a `Dockerfile` and `docker-compose.yml` that provision Apache and MariaDB.
 

--- a/root/app/Models/JobQueue.php
+++ b/root/app/Models/JobQueue.php
@@ -36,7 +36,7 @@ class JobQueue
     {
         try {
             $db = new Database();
-            $db->query("INSERT INTO status_jobs (username, account, run_at, status, payload) VALUES (:u, :a, :r, :s, :p)");
+            $db->query("INSERT IGNORE INTO status_jobs (username, account, run_at, status, payload) VALUES (:u, :a, :r, :s, :p)");
             $db->bind(':u', $username);
             $db->bind(':a', $account);
             $db->bind(':r', $runAt);
@@ -214,6 +214,7 @@ class JobQueue
             return true;
         }
 
+        $db = new Database();
         foreach ($accounts as $account) {
             $hours = array_filter(array_map('trim', explode(',', $account->cron)), 'strlen');
             if (empty($hours)) {
@@ -237,7 +238,6 @@ class JobQueue
                     continue;
                 }
                 $runAt = $runTime->format('Y-m-d H:i:s');
-                $db = new Database();
                 $db->query('SELECT id FROM status_jobs WHERE username = :u AND account = :a AND run_at = :r LIMIT 1');
                 $db->bind(':u', $account->username);
                 $db->bind(':a', $account->account);

--- a/root/install.sql
+++ b/root/install.sql
@@ -65,7 +65,8 @@ CREATE TABLE IF NOT EXISTS status_jobs (
     account VARCHAR(255) NOT NULL,
     run_at DATETIME NOT NULL,
     status ENUM('pending','processing','completed') DEFAULT 'pending',
-    payload TEXT
+    payload TEXT,
+    UNIQUE KEY unique_job (username, account, run_at)
 );
 
 -- Ensure the status_jobs table has all the required columns (alter only if necessary)
@@ -85,6 +86,16 @@ END IF;
 SET @index_exists = (SELECT COUNT(1) IndexIsThere FROM INFORMATION_SCHEMA.STATISTICS WHERE table_schema=DATABASE() AND table_name='status_jobs' AND index_name='run_at_idx');
 IF @index_exists = 0 THEN
     CREATE INDEX run_at_idx ON status_jobs (run_at);
+END IF;
+
+SET @index_exists = (SELECT COUNT(1) IndexIsThere FROM INFORMATION_SCHEMA.STATISTICS WHERE table_schema=DATABASE() AND table_name='status_jobs' AND index_name='account_idx');
+IF @index_exists = 0 THEN
+    CREATE INDEX account_idx ON status_jobs (account);
+END IF;
+
+SET @index_exists = (SELECT COUNT(1) IndexIsThere FROM INFORMATION_SCHEMA.STATISTICS WHERE table_schema=DATABASE() AND table_name='status_jobs' AND index_name='unique_job');
+IF @index_exists = 0 THEN
+    ALTER TABLE status_jobs ADD CONSTRAINT unique_job UNIQUE (username, account, run_at);
 END IF;
 
 -- Create accounts table if it doesn’t exist


### PR DESCRIPTION
## Summary
- enforce unique jobs in `status_jobs` table
- describe queue system in README
- ignore duplicate inserts and reuse DB connection in `fillQueryJobs`

## Testing
- `php -l root/app/Models/JobQueue.php`
- `php -l root/install.sql`


------
https://chatgpt.com/codex/tasks/task_e_687c50d07bc0832a90fc0292d9ed6a02