### PR TITLE
Remove run_status and refine queue handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Version 3.0.0 introduces improvements such as dedicated classes for all database
 - **Efficient Database Queries:** Uses optimized SQL queries and indexing to ensure fast data retrieval.
 - **Modular Classes:** Core logic is organized into classes such as Database, UserHandler, AccountHandler, StatusHandler, Utility, and ErrorMiddleware for maintainability and scalability.
 
-In upcoming updates I plan on optimizing the cron system with a task queue to prevent timeouts if there are many statuses to create. Also look at any other ways to secure the app.
 
 ## Features
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,9 +28,10 @@ RUN chown -R www-data:www-data /var/www && chmod -R 755 /var/www
 # Set up cron jobs
 RUN echo "0 12 1 * * php /var/www/cron.php reset_usage" >> /etc/crontab && \
     echo "0 12 * * * php /var/www/cron.php clear_list" >> /etc/crontab && \
-    echo "0 * * * * php /var/www/cron.php run_status" >> /etc/crontab && \
     echo "0 12 * * * php /var/www/cron.php cleanup" >> /etc/crontab && \
     echo "0 12 * * * php /var/www/cron.php purge_images" >> /etc/crontab && \
+    echo "0 * * * * php /var/www/cron.php fill_query" >> /etc/crontab && \
+    echo "* * * * * php /var/www/cron.php run_query" >> /etc/crontab && \
     crontab /etc/crontab
 
 

--- a/docker/docker-config.php
+++ b/docker/docker-config.php
@@ -52,6 +52,7 @@ define('DIR_MODE', 0755);
 // Cron runtime limits
 define('CRON_MAX_EXECUTION_TIME', getenv('CRON_MAX_EXECUTION_TIME') ?: 0);
 define('CRON_MEMORY_LIMIT', getenv('CRON_MEMORY_LIMIT') ?: '512M');
+define('CRON_QUEUE_LIMIT', getenv('CRON_QUEUE_LIMIT') ?: 10);
 
 // MySQL Database Connection Constants
 define('DB_HOST', getenv('DB_HOST'));

--- a/root/app/Controllers/AccountsController.php
+++ b/root/app/Controllers/AccountsController.php
@@ -18,6 +18,7 @@ use App\Core\Controller;
 use App\Core\AuthMiddleware;
 use App\Models\Account;
 use App\Models\User;
+use App\Models\JobQueue;
 
 class AccountsController extends Controller
 {
@@ -80,6 +81,7 @@ class AccountsController extends Controller
                             );
                         }
                     }
+                    JobQueue::fillQueryJobs();
                     $_SESSION['messages'][] = 'Account has been created or modified.';
                 } catch (\Exception $e) {
                     $_SESSION['messages'][] = 'Failed to create or modify account: ' . $e->getMessage();
@@ -91,6 +93,7 @@ class AccountsController extends Controller
                 $accountOwner = $_SESSION['username'];
                 try {
                     Account::deleteAccount($accountOwner, $accountName);
+                    JobQueue::fillQueryJobs();
                     $_SESSION['messages'][] = 'Account Deleted.';
                 } catch (\Exception $e) {
                     $_SESSION['messages'][] = 'Failed to delete account: ' . $e->getMessage();

--- a/root/app/Models/Account.php
+++ b/root/app/Models/Account.php
@@ -160,9 +160,7 @@ class Account
 
             if ($oldCron !== $cron || $oldDays !== $days) {
                 JobQueue::removeFuture($accountOwner, $accountName);
-                if (function_exists('\\fillQueryJobs')) {
-                    \fillQueryJobs();
-                }
+                JobQueue::fillQueryJobs();
             }
 
             return true;

--- a/root/cron.php
+++ b/root/cron.php
@@ -45,14 +45,13 @@ function logDebug(string $message): void
 
 $validJobTypes = [
                   'reset_usage',
-                  'run_status',
                   'clear_list',
                   'cleanup',
                   'purge_images',
                   'fill_query',
                   'run_query',
                  ];
-$jobType = $argv[1] ?? 'run_status'; // Default job type is 'run_status'
+$jobType = $argv[1] ?? 'run_query'; // Default job type is 'run_query'
 
 // Check for debug mode
 $debugMode = isset($argv[2]) && $argv[2] === 'debug';
@@ -72,14 +71,6 @@ switch ($jobType) {
             die(1);
         }
         logDebug("reset_usage job completed successfully.");
-        break;
-    case 'run_status':
-        logDebug("Executing run_status job.");
-        if (!runStatusUpdateJobs()) {
-            logDebug("run_status job failed.");
-            die(1);
-        }
-        logDebug("run_status job completed successfully.");
         break;
     case 'clear_list':
         logDebug("Executing clear_list job.");


### PR DESCRIPTION
## Summary
- drop obsolete `run_status` task from cron script
- refresh the queue after account changes
- optimize queue insertions by reusing a single DB handle
- document updated cron job names and environment variable
- update Docker cron setup for queue commands

## Testing
- `php -l root/cron.php`
- `php -l root/app/Controllers/AccountsController.php`
- `php -l root/app/Models/Account.php`
- `php -l root/app/Models/JobQueue.php`
- `php -l docker/docker-config.php`

------
https://chatgpt.com/codex/tasks/task_e_687c553747ec832a8fd6ede185057ead