### PR TITLE
Improve job queue failure handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,11 @@ stores the account, user, run time, and payload for a status update. The
 Set `CRON_QUEUE_LIMIT` in `root/config.php` to control how many jobs run each
 minute—choose a value that matches your server resources and API rate limits.
 
+If a job cannot be processed, `run_query` marks it as `failed`. Failed jobs
+stay in the queue so they can be retried or inspected later. When the cron
+script finishes processing jobs it removes completed and failed entries older
+than seven days.
+
 ### 🤖 Usage
 
 Login as `admin` with the password `admin`. Follow these steps:

--- a/root/install.sql
+++ b/root/install.sql
@@ -64,7 +64,7 @@ CREATE TABLE IF NOT EXISTS status_jobs (
     username VARCHAR(255) NOT NULL,
     account VARCHAR(255) NOT NULL,
     run_at DATETIME NOT NULL,
-    status ENUM('pending','processing','completed') DEFAULT 'pending',
+    status ENUM('pending','processing','completed','failed') DEFAULT 'pending',
     payload TEXT,
     UNIQUE KEY unique_job (username, account, run_at)
 );
@@ -74,7 +74,7 @@ ALTER TABLE status_jobs
 ADD COLUMN IF NOT EXISTS username VARCHAR(255) NOT NULL,
 ADD COLUMN IF NOT EXISTS account VARCHAR(255) NOT NULL,
 ADD COLUMN IF NOT EXISTS run_at DATETIME NOT NULL,
-ADD COLUMN IF NOT EXISTS status ENUM('pending','processing','completed') DEFAULT 'pending',
+ADD COLUMN IF NOT EXISTS status ENUM('pending','processing','completed','failed') DEFAULT 'pending',
 ADD COLUMN IF NOT EXISTS payload TEXT;
 
 -- Ensure indexes on status_jobs table


### PR DESCRIPTION
## Summary
- remove unused `runStatusUpdateJobs()`
- add `failed` status in database install script
- mark failed jobs in `JobQueue`
- clean up failed jobs from queue
- update cron job handler for failures
- document retry behavior in README

## Testing
- `php -l root/cron.php`
- `php -l root/app/Models/JobQueue.php`
- `composer validate --no-check-publish`

------
https://chatgpt.com/codex/tasks/task_e_687c5f79ca94832abbfe5e2027737e79