### PR TITLE
Refine daily job queue management

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,8 +328,8 @@ Install the project using the following steps:
     /usr/bin/php /PATH-TO-CRON.PHP/cron.php run_query * * * * *
      ```
    - Replace `/PATH-TO-CRON.PHP/` with the actual path to your `cron.php` file.
-  - `fill_query` populates the `status_jobs` queue with the next 24 hours of
-    scheduled posts. Run it hourly so the queue stays fresh.
+  - `fill_query` clears and repopulates the `status_jobs` queue with all posts
+    scheduled for the current day. Run it hourly so midnight jobs are not missed.
   - `run_query` processes queued jobs and marks them as completed. It will run
     up to `CRON_QUEUE_LIMIT` jobs per invocation, so schedule this command every
     minute for timely posting.

--- a/root/app/Models/Account.php
+++ b/root/app/Models/Account.php
@@ -159,8 +159,8 @@ class Account
             $db->commit();
 
             if ($oldCron !== $cron || $oldDays !== $days) {
-                JobQueue::removeFuture($accountOwner, $accountName);
-                JobQueue::fillQueryJobs();
+                JobQueue::removeRemainingToday($accountOwner, $accountName);
+                JobQueue::fillRemainingToday($accountOwner, $accountName);
             }
 
             return true;


### PR DESCRIPTION
## Summary
- clear queue and fill jobs for current day
- refresh remaining jobs when schedules change
- document daily queue behaviour

## Testing
- `php -l root/app/Models/JobQueue.php`
- `php -l root/app/Models/Account.php`
- `php -l root/cron.php`
- `php -l root/jobs.php`


------
https://chatgpt.com/codex/tasks/task_e_687c3b6fb164832a9faa01ea0a5cf107