### PR TITLE
Fix cron schedules and simplify job queue insertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,15 +321,15 @@ Install the project using the following steps:
 6. **Set Up Cron Jobs:**
    - Add the following cron jobs to automate tasks:
      ```sh
-     /usr/bin/php /PATH-TO-CRON.PHP/cron.php reset_usage 0 12 1 * *
-     /usr/bin/php /PATH-TO-CRON.PHP/cron.php clear_list 0 12 * * *
-    /usr/bin/php /PATH-TO-CRON.PHP/cron.php cleanup 0 12 * * *
-    /usr/bin/php /PATH-TO-CRON.PHP/cron.php fill_query 0 * * * *
-    /usr/bin/php /PATH-TO-CRON.PHP/cron.php run_query * * * * *
+    0 12 1 * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php reset_usage
+    0 12 * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php clear_list
+    0 12 * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php cleanup
+    0 0 * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php fill_query
+    * * * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php run_query
      ```
    - Replace `/PATH-TO-CRON.PHP/` with the actual path to your `cron.php` file.
   - `fill_query` clears and repopulates the `status_jobs` queue with all posts
-    scheduled for the current day. Run it hourly so midnight jobs are not missed.
+    scheduled for the current day. It runs once daily at midnight.
   - `run_query` processes queued jobs and marks them as completed. It will run
     up to `CRON_QUEUE_LIMIT` jobs per invocation, so schedule this command every
     minute for timely posting.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN echo "0 12 1 * * php /var/www/cron.php reset_usage" >> /etc/crontab && \
     echo "0 12 * * * php /var/www/cron.php clear_list" >> /etc/crontab && \
     echo "0 12 * * * php /var/www/cron.php cleanup" >> /etc/crontab && \
     echo "0 12 * * * php /var/www/cron.php purge_images" >> /etc/crontab && \
-    echo "0 * * * * php /var/www/cron.php fill_query" >> /etc/crontab && \
+    echo "0 0 * * * php /var/www/cron.php fill_query" >> /etc/crontab && \
     echo "* * * * * php /var/www/cron.php run_query" >> /etc/crontab && \
     crontab /etc/crontab
 

--- a/root/app/Models/JobQueue.php
+++ b/root/app/Models/JobQueue.php
@@ -313,13 +313,7 @@ class JobQueue
                 continue;
             }
             $runAt = $runTime->format('Y-m-d H:i:s');
-            $db->query('SELECT id FROM status_jobs WHERE username = :u AND account = :a AND run_at = :r LIMIT 1');
-            $db->bind(':u', $account->username);
-            $db->bind(':a', $account->account);
-            $db->bind(':r', $runAt);
-            if (!$db->single()) {
-                self::insert($account->username, $account->account, $runAt, 'pending', null, $db);
-            }
+            self::insert($account->username, $account->account, $runAt, 'pending', null, $db);
         }
     }
 }


### PR DESCRIPTION
## Summary
- update Dockerfile cron job for `fill_query` to run daily at midnight
- fix README cron examples and clarify `fill_query` runs once per day
- remove duplicate check in `JobQueue::scheduleAccount` and rely on unique key

## Testing
- `php -l root/app/Models/JobQueue.php`
- executed `root/cron.php fill_query` against a local MariaDB instance to verify jobs inserted once without duplicates

------
https://chatgpt.com/codex/tasks/task_e_687c6703ac18832aa8358edd7ccd62d4