### PR TITLE
Fix cron docs and highlight purge_images

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,12 +324,14 @@ Install the project using the following steps:
     0 12 1 * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php reset_usage
     0 12 * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php clear_list
     0 12 * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php cleanup
+    0 12 * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php purge_images
     0 0 * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php fill_query
     * * * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php run_query
      ```
    - Replace `/PATH-TO-CRON.PHP/` with the actual path to your `cron.php` file.
   - `fill_query` clears and repopulates the `status_jobs` queue with all posts
     scheduled for the current day. It runs once daily at midnight.
+  - `purge_images` deletes old PNG images from `public/images`. It runs daily at noon.
   - `run_query` processes queued jobs and marks them as completed. It will run
     up to `CRON_QUEUE_LIMIT` jobs per invocation, so schedule this command every
     minute for timely posting.


### PR DESCRIPTION
## Summary
- document the `purge_images` cron task in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c6606d508832abad154d7e961e9e4