### PR TITLE
Fix path sanitization and simplify cron job loop

### DIFF
--- a/root/app/Controllers/HomeController.php
+++ b/root/app/Controllers/HomeController.php
@@ -40,9 +40,14 @@ class HomeController extends Controller
                 try {
                     $statusImagePath = Feed::getStatusImagePath($statusId, $accountName, $accountOwner);
                     if ($statusImagePath) {
-                        $imagePath = __DIR__ . '/../../public/images/' . $accountOwner . '/' . $accountName . '/' . $statusImagePath;
-                        if (file_exists($imagePath)) {
-                            unlink($imagePath);
+                        $baseDir = realpath(__DIR__ . '/../../public/images');
+                        $safeOwner = preg_replace('/[^a-zA-Z0-9_-]/', '', $accountOwner);
+                        $safeAccount = preg_replace('/[^a-zA-Z0-9_-]/', '', $accountName);
+                        $safeImage = basename($statusImagePath);
+                        $imagePath = $baseDir . '/' . $safeOwner . '/' . $safeAccount . '/' . $safeImage;
+                        $realImagePath = realpath($imagePath);
+                        if ($realImagePath && str_starts_with($realImagePath, $baseDir) && file_exists($realImagePath)) {
+                            unlink($realImagePath);
                         }
                     }
                     Feed::deleteStatus($statusId, $accountName, $accountOwner);


### PR DESCRIPTION
## Summary
- sanitize deletion path in HomeController before removing image
- rename and refactor cron function `runStatusUpdateJobs`
- use helper `processJob()` to keep complexity low

## Testing
- `php -l root/app/Controllers/HomeController.php`
- `php -l root/cron.php`

------
https://chatgpt.com/codex/tasks/task_e_687c846964ec832a9f3998cbbf6ac702