### PR TITLE
Add password requirement for new users

### DIFF
--- a/root/app/Controllers/UsersController.php
+++ b/root/app/Controllers/UsersController.php
@@ -58,6 +58,11 @@ class UsersController extends Controller
 
                 try {
                     $userExists = User::userExists($username);
+                    if (!$userExists && empty($password)) {
+                        $_SESSION['messages'][] = 'Password is required for new users.';
+                        header('Location: /users');
+                        exit;
+                    }
                     if (!empty($password) && (!$userExists || !password_verify($password, $userExists->password))) {
                         $password = password_hash($password, PASSWORD_DEFAULT);
                     } elseif ($userExists) {


### PR DESCRIPTION
## Summary
- ensure a password is required when creating new users

## Testing
- `php -l root/app/Controllers/UsersController.php`


------
https://chatgpt.com/codex/tasks/task_e_687c97c28b2c832ab5808e7ec5adf7ea