### PR TITLE
Fix API request URL construction

### DIFF
--- a/root/app/Controllers/StatusController.php
+++ b/root/app/Controllers/StatusController.php
@@ -134,7 +134,8 @@ class StatusController
  */
     private static function openaiApiRequest(string $endpoint, ?array $data = null): array
 {
-    $url = API_ENDPOINT . $endpoint;
+    // Ensure there is exactly one slash between the endpoint base and path
+    $url = rtrim(API_ENDPOINT, '/') . '/' . ltrim($endpoint, '/');
     $headers = [
                 "Authorization: Bearer " . API_KEY,
                 "Content-Type: application/json",


### PR DESCRIPTION
## Summary
- avoid duplicated slashes in OpenAI API requests

## Testing
- `php -l root/app/Controllers/StatusController.php`


------
https://chatgpt.com/codex/tasks/task_e_687c97c3e448832a8efc871e997e692e