### PR TITLE
Fix install.sql for pre-MySQL 8

### DIFF
--- a/root/install.sql
+++ b/root/install.sql
@@ -8,16 +8,63 @@ CREATE TABLE IF NOT EXISTS ip_blacklist (
 );
 
 -- Ensure the ip_blacklist table has all the required columns (alter only if necessary)
-ALTER TABLE ip_blacklist 
-ADD COLUMN IF NOT EXISTS login_attempts INT DEFAULT 0,
-ADD COLUMN IF NOT EXISTS blacklisted BOOLEAN DEFAULT FALSE,
-ADD COLUMN IF NOT EXISTS timestamp BIGINT UNSIGNED;
+-- Add missing columns to ip_blacklist for older MySQL versions
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'ip_blacklist'
+          AND COLUMN_NAME = 'login_attempts') = 0,
+    'ALTER TABLE ip_blacklist ADD COLUMN login_attempts INT DEFAULT 0',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'ip_blacklist'
+          AND COLUMN_NAME = 'blacklisted') = 0,
+    'ALTER TABLE ip_blacklist ADD COLUMN blacklisted BOOLEAN DEFAULT FALSE',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'ip_blacklist'
+          AND COLUMN_NAME = 'timestamp') = 0,
+    'ALTER TABLE ip_blacklist ADD COLUMN timestamp BIGINT UNSIGNED',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
 
 -- Ensure indexes on ip_blacklist table
-DROP INDEX IF EXISTS blacklisted ON ip_blacklist;
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'ip_blacklist'
+          AND INDEX_NAME = 'blacklisted') > 0,
+    'DROP INDEX blacklisted ON ip_blacklist',
+    'SELECT 0');
+PREPARE drop_sql FROM @stmt;
+EXECUTE drop_sql;
+DEALLOCATE PREPARE drop_sql;
 CREATE INDEX blacklisted ON ip_blacklist (blacklisted);
 
-DROP INDEX IF EXISTS timestamp ON ip_blacklist;
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'ip_blacklist'
+          AND INDEX_NAME = 'timestamp') > 0,
+    'DROP INDEX timestamp ON ip_blacklist',
+    'SELECT 0');
+PREPARE drop_sql FROM @stmt;
+EXECUTE drop_sql;
+DEALLOCATE PREPARE drop_sql;
 CREATE INDEX timestamp ON ip_blacklist (timestamp);
 
 -- Create the status_updates table if it doesn't exist
@@ -31,21 +78,97 @@ CREATE TABLE IF NOT EXISTS status_updates (
 );
 
 -- Ensure the status_updates table has all the required columns (alter only if necessary)
-ALTER TABLE status_updates 
-ADD COLUMN IF NOT EXISTS username VARCHAR(255) NOT NULL,
-ADD COLUMN IF NOT EXISTS account VARCHAR(255) NOT NULL,
-ADD COLUMN IF NOT EXISTS status TEXT,
-ADD COLUMN IF NOT EXISTS created_at DATETIME,
-ADD COLUMN IF NOT EXISTS status_image VARCHAR(255);
+-- Add missing columns to status_updates table
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_updates'
+          AND COLUMN_NAME = 'username') = 0,
+    'ALTER TABLE status_updates ADD COLUMN username VARCHAR(255) NOT NULL',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_updates'
+          AND COLUMN_NAME = 'account') = 0,
+    'ALTER TABLE status_updates ADD COLUMN account VARCHAR(255) NOT NULL',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_updates'
+          AND COLUMN_NAME = 'status') = 0,
+    'ALTER TABLE status_updates ADD COLUMN status TEXT',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_updates'
+          AND COLUMN_NAME = 'created_at') = 0,
+    'ALTER TABLE status_updates ADD COLUMN created_at DATETIME',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_updates'
+          AND COLUMN_NAME = 'status_image') = 0,
+    'ALTER TABLE status_updates ADD COLUMN status_image VARCHAR(255)',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
 
 -- Ensure indexes on status_updates table
-DROP INDEX IF EXISTS username ON status_updates;
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_updates'
+          AND INDEX_NAME = 'username') > 0,
+    'DROP INDEX username ON status_updates',
+    'SELECT 0');
+PREPARE drop_sql FROM @stmt;
+EXECUTE drop_sql;
+DEALLOCATE PREPARE drop_sql;
 CREATE INDEX username ON status_updates (username);
 
-DROP INDEX IF EXISTS account ON status_updates;
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_updates'
+          AND INDEX_NAME = 'account') > 0,
+    'DROP INDEX account ON status_updates',
+    'SELECT 0');
+PREPARE drop_sql FROM @stmt;
+EXECUTE drop_sql;
+DEALLOCATE PREPARE drop_sql;
 CREATE INDEX account ON status_updates (account);
 
-DROP INDEX IF EXISTS created_at ON status_updates;
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_updates'
+          AND INDEX_NAME = 'created_at') > 0,
+    'DROP INDEX created_at ON status_updates',
+    'SELECT 0');
+PREPARE drop_sql FROM @stmt;
+EXECUTE drop_sql;
+DEALLOCATE PREPARE drop_sql;
 CREATE INDEX created_at ON status_updates (created_at);
 
 -- Create the status_jobs table if it doesn't exist
@@ -60,24 +183,109 @@ CREATE TABLE IF NOT EXISTS status_jobs (
 );
 
 -- Ensure the status_jobs table has all the required columns (alter only if necessary)
-ALTER TABLE status_jobs
-ADD COLUMN IF NOT EXISTS username VARCHAR(255) NOT NULL,
-ADD COLUMN IF NOT EXISTS account VARCHAR(255) NOT NULL,
-ADD COLUMN IF NOT EXISTS run_at DATETIME NOT NULL,
-ADD COLUMN IF NOT EXISTS status ENUM('pending','processing','completed','failed') DEFAULT 'pending',
-ADD COLUMN IF NOT EXISTS payload TEXT;
+-- Add missing columns to status_jobs table
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_jobs'
+          AND COLUMN_NAME = 'username') = 0,
+    'ALTER TABLE status_jobs ADD COLUMN username VARCHAR(255) NOT NULL',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_jobs'
+          AND COLUMN_NAME = 'account') = 0,
+    'ALTER TABLE status_jobs ADD COLUMN account VARCHAR(255) NOT NULL',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_jobs'
+          AND COLUMN_NAME = 'run_at') = 0,
+    'ALTER TABLE status_jobs ADD COLUMN run_at DATETIME NOT NULL',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_jobs'
+          AND COLUMN_NAME = 'status') = 0,
+    'ALTER TABLE status_jobs ADD COLUMN status ENUM(''pending'',''processing'',''completed'',''failed'') DEFAULT ''pending''',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_jobs'
+          AND COLUMN_NAME = 'payload') = 0,
+    'ALTER TABLE status_jobs ADD COLUMN payload TEXT',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
 
 -- Ensure indexes on status_jobs table
-DROP INDEX IF EXISTS username_idx ON status_jobs;
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_jobs'
+          AND INDEX_NAME = 'username_idx') > 0,
+    'DROP INDEX username_idx ON status_jobs',
+    'SELECT 0');
+PREPARE drop_sql FROM @stmt;
+EXECUTE drop_sql;
+DEALLOCATE PREPARE drop_sql;
 CREATE INDEX username_idx ON status_jobs (username);
 
-DROP INDEX IF EXISTS run_at_idx ON status_jobs;
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_jobs'
+          AND INDEX_NAME = 'run_at_idx') > 0,
+    'DROP INDEX run_at_idx ON status_jobs',
+    'SELECT 0');
+PREPARE drop_sql FROM @stmt;
+EXECUTE drop_sql;
+DEALLOCATE PREPARE drop_sql;
 CREATE INDEX run_at_idx ON status_jobs (run_at);
 
-DROP INDEX IF EXISTS account_idx ON status_jobs;
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_jobs'
+          AND INDEX_NAME = 'account_idx') > 0,
+    'DROP INDEX account_idx ON status_jobs',
+    'SELECT 0');
+PREPARE drop_sql FROM @stmt;
+EXECUTE drop_sql;
+DEALLOCATE PREPARE drop_sql;
 CREATE INDEX account_idx ON status_jobs (account);
 
-ALTER TABLE status_jobs DROP INDEX IF EXISTS unique_job;
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'status_jobs'
+          AND INDEX_NAME = 'unique_job') > 0,
+    'ALTER TABLE status_jobs DROP INDEX unique_job',
+    'SELECT 0');
+PREPARE drop_sql FROM @stmt;
+EXECUTE drop_sql;
+DEALLOCATE PREPARE drop_sql;
 ALTER TABLE status_jobs ADD CONSTRAINT unique_job UNIQUE (username, account, run_at);
 
 -- Create accounts table if it doesn’t exist
@@ -94,19 +302,96 @@ CREATE TABLE IF NOT EXISTS accounts (
 );
 
 -- Ensure the accounts table has all the required columns (alter only if necessary)
-ALTER TABLE accounts 
-ADD COLUMN IF NOT EXISTS prompt TEXT,
-ADD COLUMN IF NOT EXISTS hashtags BOOLEAN DEFAULT FALSE,
-ADD COLUMN IF NOT EXISTS link VARCHAR(255),
-ADD COLUMN IF NOT EXISTS cron VARCHAR(255),
-ADD COLUMN IF NOT EXISTS days VARCHAR(255),
-ADD COLUMN IF NOT EXISTS platform VARCHAR(255) NOT NULL;
+-- Add missing columns to accounts table
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'accounts'
+          AND COLUMN_NAME = 'prompt') = 0,
+    'ALTER TABLE accounts ADD COLUMN prompt TEXT',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'accounts'
+          AND COLUMN_NAME = 'hashtags') = 0,
+    'ALTER TABLE accounts ADD COLUMN hashtags BOOLEAN DEFAULT FALSE',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'accounts'
+          AND COLUMN_NAME = 'link') = 0,
+    'ALTER TABLE accounts ADD COLUMN link VARCHAR(255)',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'accounts'
+          AND COLUMN_NAME = 'cron') = 0,
+    'ALTER TABLE accounts ADD COLUMN cron VARCHAR(255)',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'accounts'
+          AND COLUMN_NAME = 'days') = 0,
+    'ALTER TABLE accounts ADD COLUMN days VARCHAR(255)',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'accounts'
+          AND COLUMN_NAME = 'platform') = 0,
+    'ALTER TABLE accounts ADD COLUMN platform VARCHAR(255) NOT NULL',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
 
 -- Ensure indexes on accounts table
-DROP INDEX IF EXISTS username_idx ON accounts;
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'accounts'
+          AND INDEX_NAME = 'username_idx') > 0,
+    'DROP INDEX username_idx ON accounts',
+    'SELECT 0');
+PREPARE drop_sql FROM @stmt;
+EXECUTE drop_sql;
+DEALLOCATE PREPARE drop_sql;
 CREATE INDEX username_idx ON accounts (username);
 
-DROP INDEX IF EXISTS platform_idx ON accounts;
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'accounts'
+          AND INDEX_NAME = 'platform_idx') > 0,
+    'DROP INDEX platform_idx ON accounts',
+    'SELECT 0');
+PREPARE drop_sql FROM @stmt;
+EXECUTE drop_sql;
+DEALLOCATE PREPARE drop_sql;
 CREATE INDEX platform_idx ON accounts (platform);
 
 -- Check if the users table exists before creating it and inserting default data
@@ -135,22 +420,108 @@ SELECT 'admin', '$2y$10$4idUpn/Kgpxx.GHfyLgKWeHVyZq3ugpx1mUMC6Aze9.yj.KWKTaKG', 
 WHERE @users_table_exists = 0;
 
 -- Ensure the users table has all the required columns (alter only if necessary)
-ALTER TABLE users 
-ADD COLUMN IF NOT EXISTS email VARCHAR(255) NOT NULL AFTER password,
-ADD COLUMN IF NOT EXISTS who TEXT AFTER email,
-ADD COLUMN IF NOT EXISTS `where` TEXT AFTER who,
-ADD COLUMN IF NOT EXISTS what TEXT AFTER `where`,
-ADD COLUMN IF NOT EXISTS goal TEXT AFTER what,
-ADD COLUMN IF NOT EXISTS expires DATE DEFAULT '9999-12-31' AFTER used_api_calls;
+-- Add missing columns to users table
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'users'
+          AND COLUMN_NAME = 'email') = 0,
+    'ALTER TABLE users ADD COLUMN email VARCHAR(255) NOT NULL AFTER password',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'users'
+          AND COLUMN_NAME = 'who') = 0,
+    'ALTER TABLE users ADD COLUMN who TEXT AFTER email',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'users'
+          AND COLUMN_NAME = 'where') = 0,
+    'ALTER TABLE users ADD COLUMN `where` TEXT AFTER who',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'users'
+          AND COLUMN_NAME = 'what') = 0,
+    'ALTER TABLE users ADD COLUMN what TEXT AFTER `where`',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'users'
+          AND COLUMN_NAME = 'goal') = 0,
+    'ALTER TABLE users ADD COLUMN goal TEXT AFTER what',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
+
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'users'
+          AND COLUMN_NAME = 'expires') = 0,
+    'ALTER TABLE users ADD COLUMN expires DATE DEFAULT ''9999-12-31'' AFTER used_api_calls',
+    'SELECT 0');
+PREPARE alter_sql FROM @stmt;
+EXECUTE alter_sql;
+DEALLOCATE PREPARE alter_sql;
 
 -- Ensure indexes on users table
-DROP INDEX IF EXISTS email ON users;
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'users'
+          AND INDEX_NAME = 'email') > 0,
+    'DROP INDEX email ON users',
+    'SELECT 0');
+PREPARE drop_sql FROM @stmt;
+EXECUTE drop_sql;
+DEALLOCATE PREPARE drop_sql;
 CREATE INDEX email ON users (email);
 
-DROP INDEX IF EXISTS expires ON users;
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'users'
+          AND INDEX_NAME = 'expires') > 0,
+    'DROP INDEX expires ON users',
+    'SELECT 0');
+PREPARE drop_sql FROM @stmt;
+EXECUTE drop_sql;
+DEALLOCATE PREPARE drop_sql;
 CREATE INDEX expires ON users (expires);
 
-DROP INDEX IF EXISTS admin ON users;
+SET @stmt := IF(
+    (SELECT COUNT(*) FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'users'
+          AND INDEX_NAME = 'admin') > 0,
+    'DROP INDEX admin ON users',
+    'SELECT 0');
+PREPARE drop_sql FROM @stmt;
+EXECUTE drop_sql;
+DEALLOCATE PREPARE drop_sql;
 CREATE INDEX admin ON users (admin);
 
 -- Remove old unused columns from the accounts table (only if they exist)


### PR DESCRIPTION
## Summary
- update install.sql to drop indexes and add columns only when necessary using information_schema checks

## Testing
- `composer validate --no-check-publish`

------
https://chatgpt.com/codex/tasks/task_e_687ca06b5558832aad003edc3849e38e