### PR TITLE
Fix openaiApiRequest to support GET

### DIFF
--- a/root/app/Controllers/StatusController.php
+++ b/root/app/Controllers/StatusController.php
@@ -144,9 +144,11 @@ class StatusController
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_POST, true);
     curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+    if ($data !== null) {
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+    }
     // Prevent hanging requests
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
     curl_setopt($ch, CURLOPT_TIMEOUT, 30);


### PR DESCRIPTION
## Summary
- update StatusController openaiApiRequest to only set POST options when data exists

## Testing
- `php -l root/app/Controllers/StatusController.php`


------
https://chatgpt.com/codex/tasks/task_e_687ca06ccb28832a8133f68f031f1e17