### PR TITLE
Enhance feed cleanup filters and directory permissions

### DIFF
--- a/root/app/Controllers/AccountsController.php
+++ b/root/app/Controllers/AccountsController.php
@@ -74,7 +74,11 @@ class AccountsController extends Controller
                         Account::createAccount($accountOwner, $accountName, $prompt, $platform, $hashtags, $link, $cron, $days);
                         $acctImagePath = __DIR__ . '/../../public/images/' . $accountOwner . '/' . $accountName;
                         if (!file_exists($acctImagePath)) {
-                            mkdir($acctImagePath, 0755, true);
+                            mkdir(
+                                $acctImagePath,
+                                defined('DIR_MODE') ? DIR_MODE : 0755,
+                                true
+                            );
                             $indexFilePath = $acctImagePath . '/index.php';
                             file_put_contents(
                                 $indexFilePath, '<?php die(); ?>'

--- a/root/app/Controllers/UsersController.php
+++ b/root/app/Controllers/UsersController.php
@@ -84,7 +84,11 @@ class UsersController extends Controller
                         if (!$userExists) {
                             $userImagePath = __DIR__ . '/../../public/images/' . $username;
                             if (!file_exists($userImagePath)) {
-                                mkdir($userImagePath, 0755, true);
+                                mkdir(
+                                    $userImagePath,
+                                    defined('DIR_MODE') ? DIR_MODE : 0755,
+                                    true
+                                );
                                 $indexFilePath = $userImagePath . '/index.php';
                                 file_put_contents($indexFilePath, '<?php
  die(); ?>');

--- a/root/app/Models/Feed.php
+++ b/root/app/Models/Feed.php
@@ -141,14 +141,16 @@ class Feed
      * Count the number of statuses for a specific account.
      *
      * @param string $accountName
+     * @param string $accountOwner
      * @return int
      */
-    public static function countStatuses(string $accountName): int
+    public static function countStatuses(string $accountName, string $accountOwner): int
     {
         try {
             $db = new Database();
-            $db->query("SELECT COUNT(*) as count FROM status_updates WHERE account = :account");
+            $db->query("SELECT COUNT(*) as count FROM status_updates WHERE account = :account AND username = :username");
             $db->bind(':account', $accountName);
+            $db->bind(':username', $accountOwner);
             return $db->single()->count;
         } catch (Exception $e) {
             ErrorMiddleware::logMessage("Error counting statuses: " . $e->getMessage(), 'error');
@@ -160,15 +162,17 @@ class Feed
      * Delete old statuses for a specific account.
      *
      * @param string $accountName
+     * @param string $accountOwner
      * @param int $deleteCount
      * @return bool
      */
-    public static function deleteOldStatuses(string $accountName, int $deleteCount): bool
+    public static function deleteOldStatuses(string $accountName, string $accountOwner, int $deleteCount): bool
     {
         try {
             $db = new Database();
-            $db->query("DELETE FROM status_updates WHERE account = :account ORDER BY created_at ASC LIMIT :deleteCount");
+            $db->query("DELETE FROM status_updates WHERE account = :account AND username = :username ORDER BY created_at ASC LIMIT :deleteCount");
             $db->bind(':account', $accountName);
+            $db->bind(':username', $accountOwner);
             $db->bind(':deleteCount', $deleteCount, PDO::PARAM_INT);
             $db->execute();
             return true;

--- a/root/app/Models/User.php
+++ b/root/app/Models/User.php
@@ -42,9 +42,9 @@ class User
      * Check if a user exists in the database.
      *
      * @param string $username
-     * @return mixed
+     * @return object|null
      */
-    public static function userExists(string $username): ?array
+    public static function userExists(string $username): ?object
     {
         try {
             $db = new Database();

--- a/root/cron.php
+++ b/root/cron.php
@@ -136,13 +136,14 @@ function cleanupStatuses(): bool
 
     foreach ($accounts as $account) {
         $accountName = $account->account;
+        $accountOwner = $account->username;
         logDebug("Processing account: $accountName for cleanup.");
-        $statusCount = Feed::countStatuses($accountName);
+        $statusCount = Feed::countStatuses($accountName, $accountOwner);
 
         if ($statusCount > MAX_STATUSES) {
             $deleteCount = $statusCount - MAX_STATUSES;
             logDebug("Deleting $deleteCount old statuses for account: $accountName.");
-            if (!Feed::deleteOldStatuses($accountName, $deleteCount)) {
+            if (!Feed::deleteOldStatuses($accountName, $accountOwner, $deleteCount)) {
                 logDebug("Failed to delete old statuses for account: $accountName.");
                 ErrorMiddleware::logMessage("CRON: Failed to delete old statuses for account: $accountName", 'error');
                 return false;


### PR DESCRIPTION
## Summary
- filter feed cleanup methods by account and owner
- allow directory creation with configured permissions
- update cron job to pass owner when cleaning feeds
- adjust user existence return type

## Testing
- `php -l root/app/Models/Feed.php`
- `php -l root/cron.php`
- `php -l root/app/Controllers/UsersController.php`
- `php -l root/app/Controllers/AccountsController.php`
- `php -l root/app/Models/User.php`


------
https://chatgpt.com/codex/tasks/task_e_687d5a86810c832a980eeada5ebdcd3e