### PR TITLE
Add MIT license field

### DIFF
--- a/root/composer.json
+++ b/root/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "appsbyv/v-chatgpt-smtp",
   "description": "SMTP library for sending emails in v-chatgpt-social-status-feeds.",
+  "license": "MIT",
   "type": "project",
   "require": {
     "php": "^8.0",


### PR DESCRIPTION
## Summary
- add MIT license to composer.json
- composer validate now passes without warnings

## Testing
- `composer validate root/composer.json`

------
https://chatgpt.com/codex/tasks/task_e_687d5e52426c832a8a5d681d558afce1