### PR TITLE
CSRF init and cron validation

### DIFF
--- a/root/app/Controllers/AccountsController.php
+++ b/root/app/Controllers/AccountsController.php
@@ -40,15 +40,32 @@ class AccountsController extends Controller
                 $platform = trim($_POST['platform']);
                 $hashtags = isset($_POST['hashtags']) ? (int) $_POST['hashtags'] : 0;
                 $link = trim($_POST['link']);
-                $cron = '';
+                $cron = 'null';
+                $invalidCron = false;
                 if (isset($_POST['cron']) && is_array($_POST['cron'])) {
-                    $cron = (count($_POST['cron']) === 1 && $_POST['cron'][0] === 'null') ? 'null' : implode(',', $_POST['cron']);
+                    $hours = [];
+                    foreach ($_POST['cron'] as $hour) {
+                        if ($hour === 'null') {
+                            continue;
+                        }
+                        if (ctype_digit($hour) && (int)$hour >= 0 && (int)$hour <= 23) {
+                            $hours[] = str_pad((string)(int)$hour, 2, '0', STR_PAD_LEFT);
+                        } else {
+                            $invalidCron = true;
+                        }
+                    }
+                    if (!empty($hours)) {
+                        $cron = implode(',', $hours);
+                    }
                 }
                 $days = '';
                 if (isset($_POST['days']) && is_array($_POST['days'])) {
                     $days = (count($_POST['days']) === 1 && $_POST['days'][0] === 'everyday') ? 'everyday' : implode(',', $_POST['days']);
                 }
 
+                if ($invalidCron) {
+                    $_SESSION['messages'][] = 'Invalid cron hour(s) supplied. Hours must be between 0 and 23.';
+                }
                 if (empty($cron) || empty($days) || empty($platform) || !isset($hashtags)) {
                     $_SESSION['messages'][] = 'Error processing input.';
                 }

--- a/root/app/Controllers/StatusController.php
+++ b/root/app/Controllers/StatusController.php
@@ -302,7 +302,14 @@ class StatusController
         return ["error" => $error];
     }
 
-    if (file_put_contents($image_path, file_get_contents($image_url)) === false) {
+    $imageContent = @file_get_contents($image_url);
+    if ($imageContent === false || $imageContent === '') {
+        $error = "Failed to download image for $accountName owned by $accountOwner.";
+        ErrorMiddleware::logMessage($error, 'error');
+        return ["error" => $error];
+    }
+
+    if (file_put_contents($image_path, $imageContent) === false) {
         $error = "Failed to save image for $accountName owned by $accountOwner.";
         ErrorMiddleware::logMessage($error, 'error');
         return ["error" => $error];

--- a/root/app/Models/JobQueue.php
+++ b/root/app/Models/JobQueue.php
@@ -301,7 +301,11 @@ class JobQueue
             if (!is_numeric($hour)) {
                 continue;
             }
-            $runTime = (clone $start)->setTime((int) $hour, 0);
+            $hour = (int) $hour;
+            if ($hour < 0 || $hour > 23) {
+                continue;
+            }
+            $runTime = (clone $start)->setTime($hour, 0);
             if ($runTime < $start) {
                 $runTime->modify('+1 day');
             }

--- a/root/config.php
+++ b/root/config.php
@@ -67,10 +67,6 @@ define('SMTP_PASSWORD', 'password');
 define('SMTP_FROM_EMAIL', 'no-reply@example.com');
 define('SMTP_FROM_NAME', 'ChatGPT API');
 
-// Generate CSRF token if not already set
-if (empty($_SESSION['csrf_token'])) {
-    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
-}
 
 // Validate required configuration constants
 $required_constants = ['DB_HOST', 'DB_USER', 'DB_NAME', 'API_KEY'];

--- a/root/public/index.php
+++ b/root/public/index.php
@@ -23,6 +23,9 @@ session_set_cookie_params([
     'samesite' => 'Lax',
 ]);
 session_start();
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
 
 require_once '../config.php';
 require_once '../autoload.php';

--- a/root/vendor/phpmailer/phpmailer/get_oauth_token.php
+++ b/root/vendor/phpmailer/phpmailer/get_oauth_token.php
@@ -78,6 +78,9 @@ if (!isset($_GET['code']) && !isset($_POST['provider'])) {
 require 'vendor/autoload.php';
 
 session_start();
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
 
 $providerName = '';
 $clientId = '';


### PR DESCRIPTION
## Summary
- remove CSRF generation from config
- initialize CSRF token in index entrypoints
- validate cron hours when updating accounts
- guard image downloads against failures
- skip invalid cron hours in scheduler

## Testing
- `php -l root/config.php`
- `php -l root/public/index.php`
- `php -l root/vendor/phpmailer/phpmailer/get_oauth_token.php`
- `php -l root/app/Controllers/StatusController.php`
- `php -l root/app/Controllers/AccountsController.php`
- `php -l root/app/Models/JobQueue.php`
- `composer install`

------
https://chatgpt.com/codex/tasks/task_e_687d6487d6ec832a9671b156d24fc57d