### PR TITLE
Add email header and footer

### DIFF
--- a/root/app/Core/Mailer.php
+++ b/root/app/Core/Mailer.php
@@ -70,14 +70,27 @@ class Mailer
     public static function sendTemplate(string $to, string $subject, string $template, array $data = []): bool
     {
         $templatePath = __DIR__ . '/../Templates/' . $template . '.php';
+        $headerPath   = __DIR__ . '/../Templates/email_header.php';
+        $footerPath   = __DIR__ . '/../Templates/email_footer.php';
+
         if (!file_exists($templatePath)) {
             ErrorMiddleware::logMessage('Template not found: ' . $template, 'error');
             return false;
         }
 
+        // Fallback to basic header/footer if files are missing
+        $header = file_exists($headerPath) ? $headerPath : null;
+        $footer = file_exists($footerPath) ? $footerPath : null;
+
         extract($data, EXTR_SKIP);
         ob_start();
+        if ($header) {
+            include $header;
+        }
         include $templatePath;
+        if ($footer) {
+            include $footer;
+        }
         $body = ob_get_clean();
 
         return self::send($to, $subject, $body, true);

--- a/root/app/Templates/email_footer.php
+++ b/root/app/Templates/email_footer.php
@@ -1,0 +1,6 @@
+</div>
+<div class="email-footer">
+    <p>&copy; <?= date('Y') ?> SocialRSS</p>
+</div>
+</body>
+</html>

--- a/root/app/Templates/email_header.php
+++ b/root/app/Templates/email_header.php
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: Arial, sans-serif; }
+        .email-header, .email-footer { background: #f2f2f2; padding: 10px; }
+        .email-content { padding: 10px; }
+    </style>
+</head>
+<body>
+<div class="email-header">
+    <h2>SocialRSS</h2>
+</div>
+<div class="email-content">


### PR DESCRIPTION
## Summary
- attach header and footer when sending email templates
- add new `email_header.php` and `email_footer.php` templates

## Testing
- `php -l root/app/Core/Mailer.php && php -l root/app/Templates/email_header.php && php -l root/app/Templates/email_footer.php`


------
https://chatgpt.com/codex/tasks/task_e_687d763c0478832a9b0707095f6753df