### PR TITLE
Rename cron jobs to purge_ips and purge_statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ Install the project using the following steps:
    - Add the following cron jobs to automate tasks:
      ```sh
     0 12 1 * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php reset_usage
-    0 12 * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php clear_list
-    0 12 * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php cleanup
+    0 12 * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php purge_ips
+    0 12 * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php purge_statuses
     0 12 * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php purge_images
     0 0 * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php fill_query
     * * * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php run_query
@@ -132,6 +132,8 @@ Install the project using the following steps:
    - Replace `/PATH-TO-CRON.PHP/` with the actual path to your `cron.php` file.
   - `fill_query` clears and repopulates the `status_jobs` queue with all posts
     scheduled for the current day. It runs once daily at midnight.
+  - `purge_ips` clears expired entries from the IP blacklist each day at noon.
+  - `purge_statuses` removes old statuses when an account exceeds `MAX_STATUSES`.
   - `purge_images` deletes old PNG images from `public/images`. It runs daily at noon.
   - `run_query` processes queued jobs and marks them as completed. It will run
     up to `CRON_QUEUE_LIMIT` jobs per invocation, so schedule this command every

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,8 +27,8 @@ RUN chown -R www-data:www-data /var/www && chmod -R 755 /var/www
 
 # Set up cron jobs
 RUN echo "0 12 1 * * php /var/www/cron.php reset_usage" >> /etc/crontab && \
-    echo "0 12 * * * php /var/www/cron.php clear_list" >> /etc/crontab && \
-    echo "0 12 * * * php /var/www/cron.php cleanup" >> /etc/crontab && \
+    echo "0 12 * * * php /var/www/cron.php purge_ips" >> /etc/crontab && \
+    echo "0 12 * * * php /var/www/cron.php purge_statuses" >> /etc/crontab && \
     echo "0 12 * * * php /var/www/cron.php purge_images" >> /etc/crontab && \
     echo "0 0 * * * php /var/www/cron.php fill_query" >> /etc/crontab && \
     echo "* * * * * php /var/www/cron.php run_query" >> /etc/crontab && \

--- a/root/cron.php
+++ b/root/cron.php
@@ -52,8 +52,8 @@ function logDebug(string $message): void
 
 $validJobTypes = [
                   'reset_usage',
-                  'clear_list',
-                  'cleanup',
+                  'purge_ips',
+                  'purge_statuses',
                   'purge_images',
                   'fill_query',
                   'run_query',
@@ -79,21 +79,21 @@ switch ($jobType) {
         }
         logDebug("reset_usage job completed successfully.");
         break;
-    case 'clear_list':
-        logDebug("Executing clear_list job.");
-        if (!clearList()) {
-            logDebug("clear_list job failed.");
+    case 'purge_ips':
+        logDebug("Executing purge_ips job.");
+        if (!purgeIps()) {
+            logDebug("purge_ips job failed.");
             die(1);
         }
-        logDebug("clear_list job completed successfully.");
+        logDebug("purge_ips job completed successfully.");
         break;
-    case 'cleanup':
-        logDebug("Executing cleanup job.");
-        if (!cleanupStatuses()) {
-            logDebug("cleanup job failed.");
+    case 'purge_statuses':
+        logDebug("Executing purge_statuses job.");
+        if (!purgeStatuses()) {
+            logDebug("purge_statuses job failed.");
             die(1);
         }
-        logDebug("cleanup job completed successfully.");
+        logDebug("purge_statuses job completed successfully.");
         break;
     case 'purge_images':
         logDebug("Executing purge_images job.");
@@ -132,10 +132,10 @@ switch ($jobType) {
  * This function checks the number of statuses for each account and deletes the oldest ones if they exceed the maximum allowed.
  * This helps to manage storage and keep the database performant.
  */
-function cleanupStatuses(): bool
+function purgeStatuses(): bool
 {
     global $debugMode;
-    logDebug("Fetching all accounts for cleanup.");
+    logDebug("Fetching all accounts for status purge.");
     $accounts = Account::getAllAccounts();
     if (empty($accounts)) {
         logDebug("No accounts found or failed to get accounts.");
@@ -146,7 +146,7 @@ function cleanupStatuses(): bool
     foreach ($accounts as $account) {
         $accountName = $account->account;
         $accountOwner = $account->username;
-        logDebug("Processing account: $accountName for cleanup.");
+        logDebug("Processing account: $accountName for status purge.");
         $statusCount = Feed::countStatuses($accountName, $accountOwner);
 
         if ($statusCount > MAX_STATUSES) {
@@ -225,11 +225,11 @@ function resetApi(): bool
 }
 
 /**
- * Clear the IP blacklist.
- * This function clears the IP blacklist, removing all entries.
- * This is typically run periodically to ensure that the blacklist does not grow indefinitely.
+ * Purge old entries from the IP blacklist.
+ * This function calls Security::clearIpBlacklist() to remove expired IP addresses.
+ * Schedule periodically so the blacklist does not grow indefinitely.
  */
-function clearList(): bool
+function purgeIps(): bool
 {
     global $debugMode;
     logDebug("Clearing IP blacklist.");


### PR DESCRIPTION
## Summary
- rename `clear_list` job to `purge_ips`
- rename `cleanup` job to `purge_statuses`
- update Dockerfile and README for new cron names
- adjust cron.php functions and logging

## Testing
- `composer validate --no-check-publish`
- `composer install --no-interaction`
- `php -l cron.php`


------
https://chatgpt.com/codex/tasks/task_e_687d9cdb8ed0832aa34937a622631f9c