### PR TITLE
Fix cron job variable scope

### DIFF
--- a/root/cron.php
+++ b/root/cron.php
@@ -36,7 +36,8 @@ ini_set('max_execution_time', (string) (defined('CRON_MAX_EXECUTION_TIME') ? CRO
 ini_set('memory_limit', defined('CRON_MEMORY_LIMIT') ? CRON_MEMORY_LIMIT : '512M');
 
 // Run the job logic within the error middleware handler
-ErrorMiddleware::handle(function () use (&$jobType) {
+ErrorMiddleware::handle(function () {
+    global $argv;
 
 $validJobTypes = [
     'daily',


### PR DESCRIPTION
## Summary
- remove superfluous `use (&$jobType)` from the error handler closure
- access CLI arguments inside the closure using `global $argv`

## Testing
- `php -l root/cron.php`
- `php root/cron.php run_query` *(fails to run due to missing configuration but no undefined variable notices)*

------
https://chatgpt.com/codex/tasks/task_e_68842e7467b4832ab3aaadc13e3aa625