### PR TITLE
Prevent cross-user status actions

### DIFF
--- a/root/app/Controllers/HomeController.php
+++ b/root/app/Controllers/HomeController.php
@@ -36,7 +36,12 @@ class HomeController extends Controller
 
             if (isset($_POST['delete_status'])) {
                 $accountName = trim($_POST['account']);
-                $accountOwner = trim($_POST['username']);
+                $accountOwner = $_SESSION['username'];
+                if (isset($_POST['username']) && $accountOwner !== trim($_POST['username'])) {
+                    $_SESSION['messages'][] = 'Username mismatch.';
+                    header('Location: /home');
+                    exit;
+                }
                 $statusId = (int) $_POST['id'];
                 try {
                     $statusImagePath = Feed::getStatusImagePath($statusId, $accountName, $accountOwner);
@@ -60,7 +65,12 @@ class HomeController extends Controller
                 exit;
             } elseif (isset($_POST['generate_status'])) {
                 $accountName = trim($_POST['account']);
-                $accountOwner = trim($_POST['username']);
+                $accountOwner = $_SESSION['username'];
+                if (isset($_POST['username']) && $accountOwner !== trim($_POST['username'])) {
+                    $_SESSION['messages'][] = 'Username mismatch.';
+                    header('Location: /home');
+                    exit;
+                }
                 try {
                     $userInfo = User::getUserInfo($accountOwner);
                     if ($userInfo && $userInfo->used_api_calls >= $userInfo->max_api_calls) {


### PR DESCRIPTION
## Summary
- ensure delete and generate status actions use the logged-in user
- optionally check posted username matches the session

## Testing
- `php -l root/app/Controllers/HomeController.php`

------
https://chatgpt.com/codex/tasks/task_e_68842e92efc8832aba67aa72493ddce1