### PR TITLE
Ensure password changes use session username

### DIFF
--- a/root/app/Controllers/InfoController.php
+++ b/root/app/Controllers/InfoController.php
@@ -32,7 +32,8 @@ class InfoController extends Controller
             }
 
             if (isset($_POST['change_password'])) {
-                $username = $_POST['username'];
+                // Ignore any posted username and use the logged in user
+                $username = $_SESSION['username'];
                 $password = $_POST['password'];
                 $password2 = $_POST['password2'];
                 if ($password !== $password2) {

--- a/root/app/Views/info.php
+++ b/root/app/Views/info.php
@@ -57,8 +57,8 @@
             <form class="form-group" method="post">
                 <!-- Username input field (readonly) -->
                 <label for="username">Username:</label>
-                <input class="form-input" type="text" name="username" id="username" value="<?php
- echo htmlspecialchars($_SESSION['username']); ?>" readonly required>
+                <input class="form-input" type="text" id="username" value="<?php
+ echo htmlspecialchars($_SESSION['username']); ?>" readonly>
                 <!-- New password input field -->
                 <label for="password">New Password:</label>
                 <input class="form-input" type="password" name="password" id="password" required>


### PR DESCRIPTION
## Summary
- ignore posted username when changing password
- rely on session username only
- prevent username from being submitted in the change password form

## Testing
- `php -l app/Controllers/InfoController.php`
- `php -l app/Views/info.php`


------
https://chatgpt.com/codex/tasks/task_e_68842ea7e0dc832a982b84eef3efd239