### PR TITLE
Refactor AuthController login flow

### DIFF
--- a/root/app/Controllers/AuthController.php
+++ b/root/app/Controllers/AuthController.php
@@ -23,57 +23,71 @@ class AuthController extends Controller
 {
     public static function handleRequest(): void
     {
-        if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true) {
-            if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['logout'])) {
-                unset($_SESSION['is_admin']);
-                session_destroy();
-                header('Location: /login');
-                exit();
-            }
+        if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true && !($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['logout']))) {
             header('Location: /');
             exit();
         }
 
+        if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['logout'])) {
+            self::logoutUser();
+        }
+
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {
+            if (!self::validCsrfToken($_POST['csrf_token'] ?? '')) {
                 $error = 'Invalid CSRF token. Please try again.';
                 ErrorMiddleware::logMessage($error);
                 $_SESSION['messages'][] = $error;
-                (new self())->render('login', []);
-                return;
-            }
-
-            $username = trim($_POST['username'] ?? '');
-            $password = trim($_POST['password'] ?? '');
-
-            $userInfo = User::getUserInfo($username);
-
-            // Verify user credentials against hashed password
-            if ($userInfo && password_verify($password, $userInfo->password)) {
-                $_SESSION['logged_in'] = true;
-                $_SESSION['username'] = $userInfo->username;
-                $_SESSION['user_agent'] = $_SERVER['HTTP_USER_AGENT'];
-                $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
-                $_SESSION['is_admin'] = $userInfo->admin;
-                $_SESSION['timeout'] = time();
-                session_regenerate_id(true);
-                header('Location: /');
-                exit();
-            }
-
-            $ip = $_SERVER['REMOTE_ADDR'];
-            if (Security::isBlacklisted($ip)) {
-                $error = 'Your IP has been blacklisted due to multiple failed login attempts.';
-                ErrorMiddleware::logMessage($error);
-                $_SESSION['messages'][] = $error;
             } else {
-                Security::updateFailedAttempts($ip);
-                $error = 'Invalid username or password.';
-                ErrorMiddleware::logMessage($error);
-                $_SESSION['messages'][] = $error;
+                $username = trim($_POST['username'] ?? '');
+                $password = trim($_POST['password'] ?? '');
+                $userInfo = self::validateCredentials($username, $password);
+
+                if ($userInfo) {
+                    $_SESSION['logged_in'] = true;
+                    $_SESSION['username'] = $userInfo->username;
+                    $_SESSION['user_agent'] = $_SERVER['HTTP_USER_AGENT'];
+                    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+                    $_SESSION['is_admin'] = $userInfo->admin;
+                    $_SESSION['timeout'] = time();
+                    session_regenerate_id(true);
+                    header('Location: /');
+                    exit();
+                }
+
+                $ip = $_SERVER['REMOTE_ADDR'];
+                if (Security::isBlacklisted($ip)) {
+                    $error = 'Your IP has been blacklisted due to multiple failed login attempts.';
+                    ErrorMiddleware::logMessage($error);
+                    $_SESSION['messages'][] = $error;
+                } else {
+                    Security::updateFailedAttempts($ip);
+                    $error = 'Invalid username or password.';
+                    ErrorMiddleware::logMessage($error);
+                    $_SESSION['messages'][] = $error;
+                }
             }
         }
 
         (new self())->render('login', []);
+    }
+
+    private static function logoutUser(): void
+    {
+        unset($_SESSION['is_admin']);
+        session_destroy();
+        header('Location: /login');
+        exit();
+    }
+
+    private static function validCsrfToken(string $token): bool
+    {
+        return isset($_SESSION['csrf_token']) && $token === $_SESSION['csrf_token'];
+    }
+
+    private static function validateCredentials(string $username, string $password): ?object
+    {
+        $userInfo = User::getUserInfo($username);
+
+        return ($userInfo && password_verify($password, $userInfo->password)) ? $userInfo : null;
     }
 }


### PR DESCRIPTION
## Summary
- refactor auth controller to use guard clauses
- extract logout and credential validation into private methods
- validate CSRF token using helper method

## Testing
- `composer install --no-interaction`
- `php -l app/Controllers/AuthController.php`


------
https://chatgpt.com/codex/tasks/task_e_688451a71020832aaf40af10d2f2ff73