### PR TITLE
Refactor InfoController CSRF and form handling

### DIFF
--- a/root/app/Controllers/InfoController.php
+++ b/root/app/Controllers/InfoController.php
@@ -25,55 +25,21 @@ class InfoController extends Controller
         AuthMiddleware::check();
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {
+            $token = $_POST['csrf_token'] ?? '';
+            if (!self::isCsrfValid($token)) {
                 $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
                 header('Location: /info');
-                exit;
+                return;
             }
 
             if (isset($_POST['change_password'])) {
-                // Ignore any posted username and use the logged in user
-                $username = $_SESSION['username'];
-                $password = $_POST['password'];
-                $password2 = $_POST['password2'];
-                if ($password !== $password2) {
-                    $_SESSION['messages'][] = 'Passwords do not match. Please try again.';
-                }
-                if (!preg_match('/^(?=.*[A-Za-z])(?=.*\d)(?=.*[\W_]).{8,16}$/', $password)) {
-                    $_SESSION['messages'][] = 'Password must be 8-16 characters long, including at least one letter, one number, and one symbol.';
-                }
-                if (!empty($_SESSION['messages'])) {
-                    header('Location: /info');
-                    exit;
-                }
-                $hashedPassword = password_hash($password, PASSWORD_DEFAULT);
-                try {
-                    User::updatePassword($username, $hashedPassword);
-                    $_SESSION['messages'][] = 'Password Updated!';
-                } catch (\Exception $e) {
-                    $_SESSION['messages'][] = 'Password update failed: ' . $e->getMessage();
-                }
-                header('Location: /info');
-                exit;
-            } elseif (isset($_POST['update_profile'])) {
-                $username = $_SESSION['username'];
-                $who = trim($_POST['who']);
-                $where = trim($_POST['where']);
-                $what = trim($_POST['what']);
-                $goal = trim($_POST['goal']);
-                if (empty($who) || empty($where) || empty($what) || empty($goal)) {
-                    $_SESSION['messages'][] = 'All fields are required.';
-                    header('Location: /info');
-                    exit;
-                }
-                try {
-                    User::updateProfile($username, $who, $where, $what, $goal);
-                    $_SESSION['messages'][] = 'Profile Updated!';
-                } catch (\Exception $e) {
-                    $_SESSION['messages'][] = 'Profile update failed: ' . $e->getMessage();
-                }
-                header('Location: /info');
-                exit;
+                self::processPasswordChange();
+                return;
+            }
+
+            if (isset($_POST['update_profile'])) {
+                self::processProfileUpdate();
+                return;
             }
         }
 
@@ -84,6 +50,63 @@ class InfoController extends Controller
             'profileData' => $profileData,
             'systemMsg' => $systemMsg,
         ]);
+    }
+
+    private static function isCsrfValid(string $token): bool
+    {
+        return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
+    }
+
+    private static function processPasswordChange(): void
+    {
+        $username = $_SESSION['username'];
+        $password = $_POST['password'];
+        $password2 = $_POST['password2'];
+
+        if ($password !== $password2) {
+            $_SESSION['messages'][] = 'Passwords do not match. Please try again.';
+        }
+
+        if (!preg_match('/^(?=.*[A-Za-z])(?=.*\d)(?=.*[\W_]).{8,16}$/', $password)) {
+            $_SESSION['messages'][] = 'Password must be 8-16 characters long, including at least one letter, one number, and one symbol.';
+        }
+
+        if (!empty($_SESSION['messages'])) {
+            header('Location: /info');
+            return;
+        }
+
+        $hashedPassword = password_hash($password, PASSWORD_DEFAULT);
+        try {
+            User::updatePassword($username, $hashedPassword);
+            $_SESSION['messages'][] = 'Password Updated!';
+        } catch (\Exception $e) {
+            $_SESSION['messages'][] = 'Password update failed: ' . $e->getMessage();
+        }
+        header('Location: /info');
+    }
+
+    private static function processProfileUpdate(): void
+    {
+        $username = $_SESSION['username'];
+        $who = trim($_POST['who']);
+        $where = trim($_POST['where']);
+        $what = trim($_POST['what']);
+        $goal = trim($_POST['goal']);
+
+        if (empty($who) || empty($where) || empty($what) || empty($goal)) {
+            $_SESSION['messages'][] = 'All fields are required.';
+            header('Location: /info');
+            return;
+        }
+
+        try {
+            User::updateProfile($username, $who, $where, $what, $goal);
+            $_SESSION['messages'][] = 'Profile Updated!';
+        } catch (\Exception $e) {
+            $_SESSION['messages'][] = 'Profile update failed: ' . $e->getMessage();
+        }
+        header('Location: /info');
     }
 
     public static function generateProfileDataAttributes(string $username): string


### PR DESCRIPTION
## Summary
- validate CSRF tokens first and return early
- split password and profile logic into private helpers
- use early returns instead of elseif

## Testing
- `php -l root/app/Controllers/InfoController.php`
- `composer install --no-interaction`

------
https://chatgpt.com/codex/tasks/task_e_688453ce7de0832aaaa31d489bd501b7