### PR TITLE
Simplify cron blacklist purge

### DIFF
--- a/root/cron.php
+++ b/root/cron.php
@@ -165,11 +165,7 @@ function resetApi(): bool
  */
 function purgeIps(): bool
 {
-    if (!Security::clearIpBlacklist()) {
-        
-        return false;
-    }
-    return true;
+    return Security::clearIpBlacklist();
 }
 
 


### PR DESCRIPTION
## Summary
- simplify purgeIps helper by returning the helper call directly

## Testing
- `php -l root/cron.php`
- `composer validate --no-check-all`

------
https://chatgpt.com/codex/tasks/task_e_68845b27c628832a96a358f2517c2386