### PR TITLE
Refactor view scripts

### DIFF
--- a/root/app/Views/accounts.php
+++ b/root/app/Views/accounts.php
@@ -108,32 +108,18 @@ require 'partials/header.php';
                 });
 
                 // Select the appropriate cron options
-                const selectedCronValues = this.dataset.cron ? this.dataset.cron.split(',') : [];
-                if (selectedCronValues.length === 0 || selectedCronValues.includes("off")) {
-                    const offOption = cronField.querySelector('option[value="off"]');
-                    offOption.selected = true;
-                } else {
-                    selectedCronValues.forEach(value => {
-                        const option = cronField.querySelector(`option[value="${value}"]`);
-                        if (option) {
-                            option.selected = true;
-                        }
-                    });
-                }
+                const selectedCronValues = this.dataset.cron?.split(',') || [];
+                selectedCronValues.length === 0 || selectedCronValues.includes('off')
+                    ? cronField.querySelector('option[value="off"]').selected = true
+                    : selectedCronValues.forEach(value =>
+                        cronField.querySelector(`option[value="${value}"]`)?.selected = true);
 
                 // Select the appropriate days options
-                const selectedDaysValues = this.dataset.days ? this.dataset.days.split(',') : [];
-                if (selectedDaysValues.length === 0 || selectedDaysValues.includes("everyday")) {
-                    const everydayOption = daysField.querySelector('option[value="everyday"]');
-                    everydayOption.selected = true;
-                } else {
-                    selectedDaysValues.forEach(value => {
-                        const option = daysField.querySelector(`option[value="${value}"]`);
-                        if (option) {
-                            option.selected = true;
-                        }
-                    });
-                }
+                const selectedDaysValues = this.dataset.days?.split(',') || [];
+                selectedDaysValues.length === 0 || selectedDaysValues.includes('everyday')
+                    ? daysField.querySelector('option[value="everyday"]').selected = true
+                    : selectedDaysValues.forEach(value =>
+                        daysField.querySelector(`option[value="${value}"]`)?.selected = true);
 
                 platformSelect.value = this.dataset.platform;
                 accountNameField.readOnly = true;
@@ -145,30 +131,20 @@ require 'partials/header.php';
             accountNameField.readOnly = false;
         });
 
-        const accountList = document.querySelector('.account-right');
-        if (accountList) {
-            accountList.addEventListener('click', function(event) {
-                if (event.target.id !== 'update-button') {
-                    accountNameField.readOnly = false;
-                }
-            });
-        }
+        document.querySelector('.account-right')?.addEventListener('click', event => {
+            event.target.id !== 'update-button' && (accountNameField.readOnly = false);
+        });
 
         const daysField = document.querySelector('#days');
-        daysField.addEventListener('change', function() {
-            const selectedOptions = Array.from(daysField.selectedOptions).map(option => option.value);
+        daysField.addEventListener('change', () => {
+            const selectedOptions = Array.from(daysField.selectedOptions).map(opt => opt.value);
 
             // Ensure only 'everyday' or specific days are selected, not both
-            if (selectedOptions.includes('everyday')) {
-                Array.from(daysField.options).forEach(option => {
-                    if (option.value !== 'everyday') {
-                        option.selected = false;
-                    }
-                });
-            } else if (selectedOptions.length > 0) {
-                const everydayOption = daysField.querySelector('option[value="everyday"]');
-                everydayOption.selected = false;
-            }
+            selectedOptions.includes('everyday')
+                ? Array.from(daysField.options).forEach(opt =>
+                    opt.value !== 'everyday' && (opt.selected = false))
+                : selectedOptions.length > 0 &&
+                    (daysField.querySelector('option[value="everyday"]').selected = false);
         });
     });
 </script>

--- a/root/app/Views/home.php
+++ b/root/app/Views/home.php
@@ -115,17 +115,14 @@ require 'partials/header.php';
         const allButtons = document.querySelectorAll('.collapse-button');
 
         // Close all other sections
-        allStatusContents.forEach(content => {
-            if (content !== statusContent) content.style.display = 'none';
-        });
+        allStatusContents.forEach(content =>
+            content !== statusContent && (content.style.display = 'none'));
 
-        allAccountActionContainers.forEach(container => {
-            if (container !== accountActionContainer) container.style.display = 'none';
-        });
+        allAccountActionContainers.forEach(container =>
+            container !== accountActionContainer && (container.style.display = 'none'));
 
-        allButtons.forEach(btn => {
-            if (btn !== button) btn.querySelector('i').className = 'icon icon-arrow-right';
-        });
+        allButtons.forEach(btn =>
+            btn !== button && (btn.querySelector('i').className = 'icon icon-arrow-right'));
 
         // Toggle the clicked section
         const isOpen = statusContent.style.display === 'flex';
@@ -238,13 +235,11 @@ require 'partials/header.php';
                     };
 
                     // Share content if supported
-                    if (navigator.share && navigator.canShare && navigator.canShare(shareData)) {
-                        await navigator.share(shareData);
-                        console.log('Content shared successfully');
-                    } else {
-                        console.log('Sharing not supported.');
-                        showToast('Sharing not supported on this device.');
-                    }
+                    navigator.share && navigator.canShare && navigator.canShare(shareData)
+                        ? (await navigator.share(shareData),
+                            console.log('Content shared successfully'))
+                        : (console.log('Sharing not supported.'),
+                            showToast('Sharing not supported on this device.'));
                 } catch (error) {
                     console.error('Error sharing:', error);
                     showToast('Error occurred while sharing.');


### PR DESCRIPTION
## Summary
- simplify account selection logic with ternaries
- remove redundant DOM checks
- compact JS loops in home view
- shorten share handler

## Testing
- `php -l app/Views/accounts.php`
- `php -l app/Views/home.php`
- `composer validate --no-check-all`

------
https://chatgpt.com/codex/tasks/task_e_68845b4a24bc832a9367e1f960f10191