### PR TITLE
Remove duplicate auth checks

### DIFF
--- a/root/app/Controllers/AccountsController.php
+++ b/root/app/Controllers/AccountsController.php
@@ -15,7 +15,6 @@
 namespace App\Controllers;
 
 use App\Core\Controller;
-use App\Core\AuthMiddleware;
 use App\Models\Account;
 use App\Models\User;
 use App\Models\JobQueue;
@@ -24,7 +23,6 @@ class AccountsController extends Controller
 {
     public static function handleRequest(): void
     {
-        AuthMiddleware::check();
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if (!self::isValidCsrf()) {

--- a/root/app/Controllers/HomeController.php
+++ b/root/app/Controllers/HomeController.php
@@ -15,7 +15,6 @@
 namespace App\Controllers;
 
 use App\Core\Controller;
-use App\Core\AuthMiddleware;
 use App\Core\Mailer;
 use App\Controllers\StatusController;
 use App\Models\User;
@@ -25,7 +24,6 @@ class HomeController extends Controller
 {
     public static function handleRequest(): void
     {
-        AuthMiddleware::check();
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {

--- a/root/app/Controllers/InfoController.php
+++ b/root/app/Controllers/InfoController.php
@@ -15,14 +15,12 @@
 namespace App\Controllers;
 
 use App\Core\Controller;
-use App\Core\AuthMiddleware;
 use App\Models\User;
 
 class InfoController extends Controller
 {
     public static function handleRequest(): void
     {
-        AuthMiddleware::check();
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $token = $_POST['csrf_token'] ?? '';

--- a/root/app/Controllers/UsersController.php
+++ b/root/app/Controllers/UsersController.php
@@ -15,7 +15,6 @@
 namespace App\Controllers;
 
 use App\Core\Controller;
-use App\Core\AuthMiddleware;
 use App\Core\Mailer;
 use App\Models\User;
 
@@ -23,7 +22,6 @@ class UsersController extends Controller
 {
     public static function handleRequest(): void
     {
-        AuthMiddleware::check();
 
         if (empty($_SESSION['is_admin'])) {
             http_response_code(403);


### PR DESCRIPTION
## Summary
- delete `AuthMiddleware::check()` calls from controllers
- rely on the router for authentication logic

## Testing
- `composer validate --no-check-all --strict`
- `php -l app/Controllers/AccountsController.php`
- `php -l app/Controllers/HomeController.php`
- `php -l app/Controllers/InfoController.php`
- `php -l app/Controllers/UsersController.php`


------
https://chatgpt.com/codex/tasks/task_e_688460d7f270832ab8296908f7e50c6b