### PR TITLE
Ensure exit after redirect headers

### DIFF
--- a/root/app/Controllers/AccountsController.php
+++ b/root/app/Controllers/AccountsController.php
@@ -28,7 +28,7 @@ class AccountsController extends Controller
             if (!self::isValidCsrf()) {
                 $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
                 header('Location: /accounts');
-                return;
+                exit;
             }
 
             if (isset($_POST['edit_account'])) {
@@ -109,7 +109,7 @@ class AccountsController extends Controller
 
         if (!empty($_SESSION['messages'])) {
             header('Location: /accounts');
-            return;
+            exit;
         }
 
         try {
@@ -137,6 +137,7 @@ class AccountsController extends Controller
             $_SESSION['messages'][] = 'Failed to create or modify account: ' . $e->getMessage();
         }
         header('Location: /accounts');
+        exit;
     }
 
     private static function deleteAccount(): void
@@ -151,6 +152,7 @@ class AccountsController extends Controller
             $_SESSION['messages'][] = 'Failed to delete account: ' . $e->getMessage();
         }
         header('Location: /accounts');
+        exit;
     }
 
     /**

--- a/root/app/Controllers/InfoController.php
+++ b/root/app/Controllers/InfoController.php
@@ -27,7 +27,7 @@ class InfoController extends Controller
             if (!self::isCsrfValid($token)) {
                 $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
                 header('Location: /info');
-                return;
+                exit;
             }
 
             if (isset($_POST['change_password'])) {
@@ -71,7 +71,7 @@ class InfoController extends Controller
 
         if (!empty($_SESSION['messages'])) {
             header('Location: /info');
-            return;
+            exit;
         }
 
         $hashedPassword = password_hash($password, PASSWORD_DEFAULT);
@@ -82,6 +82,7 @@ class InfoController extends Controller
             $_SESSION['messages'][] = 'Password update failed: ' . $e->getMessage();
         }
         header('Location: /info');
+        exit;
     }
 
     private static function processProfileUpdate(): void
@@ -95,7 +96,7 @@ class InfoController extends Controller
         if (empty($who) || empty($where) || empty($what) || empty($goal)) {
             $_SESSION['messages'][] = 'All fields are required.';
             header('Location: /info');
-            return;
+            exit;
         }
 
         try {
@@ -105,6 +106,7 @@ class InfoController extends Controller
             $_SESSION['messages'][] = 'Profile update failed: ' . $e->getMessage();
         }
         header('Location: /info');
+        exit;
     }
 
     public static function generateProfileDataAttributes(string $username): string


### PR DESCRIPTION
## Summary
- standardize usage of `exit` after `header()` calls
- update `AccountsController` and `InfoController` to follow the convention

## Testing
- `php -l root/app/Controllers/AccountsController.php`
- `php -l root/app/Controllers/InfoController.php`
- `php -l root/app/Controllers/HomeController.php`
- `php -l root/app/Controllers/UsersController.php`

------
https://chatgpt.com/codex/tasks/task_e_68846313b1bc832aa3be6c2145dcc8df