### PR TITLE
Add shared CSRF validation helper

### DIFF
--- a/root/app/Controllers/AccountsController.php
+++ b/root/app/Controllers/AccountsController.php
@@ -18,6 +18,7 @@ use App\Core\Controller;
 use App\Models\Account;
 use App\Models\User;
 use App\Models\JobQueue;
+use App\Core\Csrf;
 
 class AccountsController extends Controller
 {
@@ -25,7 +26,7 @@ class AccountsController extends Controller
     {
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            if (!self::isValidCsrf()) {
+            if (!Csrf::validate($_POST['csrf_token'] ?? '')) {
                 $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
                 header('Location: /accounts');
                 exit;
@@ -53,11 +54,6 @@ class AccountsController extends Controller
             'accountList' => $accountList,
             'calendarOverview' => $calendarOverview,
         ]);
-    }
-
-    private static function isValidCsrf(): bool
-    {
-        return isset($_POST['csrf_token']) && $_POST['csrf_token'] === $_SESSION['csrf_token'];
     }
 
     private static function createOrUpdateAccount(): void

--- a/root/app/Controllers/AuthController.php
+++ b/root/app/Controllers/AuthController.php
@@ -18,6 +18,7 @@ use App\Models\User;
 use App\Models\Security;
 use App\Core\ErrorMiddleware;
 use App\Core\Controller;
+use App\Core\Csrf;
 
 class AuthController extends Controller
 {
@@ -33,7 +34,7 @@ class AuthController extends Controller
         }
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            if (!self::validCsrfToken($_POST['csrf_token'] ?? '')) {
+            if (!Csrf::validate($_POST['csrf_token'] ?? '')) {
                 $error = 'Invalid CSRF token. Please try again.';
                 ErrorMiddleware::logMessage($error);
                 $_SESSION['messages'][] = $error;
@@ -77,11 +78,6 @@ class AuthController extends Controller
         session_destroy();
         header('Location: /login');
         exit();
-    }
-
-    private static function validCsrfToken(string $token): bool
-    {
-        return isset($_SESSION['csrf_token']) && $token === $_SESSION['csrf_token'];
     }
 
     private static function validateCredentials(string $username, string $password): ?object

--- a/root/app/Controllers/HomeController.php
+++ b/root/app/Controllers/HomeController.php
@@ -19,6 +19,7 @@ use App\Core\Mailer;
 use App\Controllers\StatusController;
 use App\Models\User;
 use App\Models\Feed;
+use App\Core\Csrf;
 
 class HomeController extends Controller
 {
@@ -26,7 +27,7 @@ class HomeController extends Controller
     {
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {
+            if (!Csrf::validate($_POST['csrf_token'] ?? '')) {
                 $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
                 header('Location: /home');
                 exit;

--- a/root/app/Controllers/InfoController.php
+++ b/root/app/Controllers/InfoController.php
@@ -16,6 +16,7 @@ namespace App\Controllers;
 
 use App\Core\Controller;
 use App\Models\User;
+use App\Core\Csrf;
 
 class InfoController extends Controller
 {
@@ -24,7 +25,7 @@ class InfoController extends Controller
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $token = $_POST['csrf_token'] ?? '';
-            if (!self::isCsrfValid($token)) {
+            if (!Csrf::validate($token)) {
                 $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
                 header('Location: /info');
                 exit;
@@ -48,11 +49,6 @@ class InfoController extends Controller
             'profileData' => $profileData,
             'systemMsg' => $systemMsg,
         ]);
-    }
-
-    private static function isCsrfValid(string $token): bool
-    {
-        return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
     }
 
     private static function processPasswordChange(): void

--- a/root/app/Controllers/UsersController.php
+++ b/root/app/Controllers/UsersController.php
@@ -17,6 +17,7 @@ namespace App\Controllers;
 use App\Core\Controller;
 use App\Core\Mailer;
 use App\Models\User;
+use App\Core\Csrf;
 
 class UsersController extends Controller
 {
@@ -29,7 +30,7 @@ class UsersController extends Controller
         }
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {
+            if (!Csrf::validate($_POST['csrf_token'] ?? '')) {
                 $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
                 header('Location: /users');
                 exit;

--- a/root/app/Core/Csrf.php
+++ b/root/app/Core/Csrf.php
@@ -1,0 +1,23 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+
+/**
+ * Project: SocialRSS
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: Csrf.php
+ * Description: CSRF validation helper
+ */
+
+namespace App\Core;
+
+class Csrf
+{
+    public static function validate(string $token): bool
+    {
+        return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
+    }
+}


### PR DESCRIPTION
## Summary
- create a new `Csrf` utility for token checking
- use the new helper across controllers
- remove old duplicate CSRF validation methods

## Testing
- `php -l root/app/Core/Csrf.php`
- `php -l root/app/Controllers/AuthController.php`
- `php -l root/app/Controllers/HomeController.php`
- `php -l root/app/Controllers/AccountsController.php`
- `php -l root/app/Controllers/UsersController.php`
- `php -l root/app/Controllers/InfoController.php`
- `composer dump-autoload`

------
https://chatgpt.com/codex/tasks/task_e_6884659d4898832ab0d617307e0f6db1