### PR TITLE
Move StatusController to Services

### DIFF
--- a/root/app/Controllers/HomeController.php
+++ b/root/app/Controllers/HomeController.php
@@ -16,7 +16,7 @@ namespace App\Controllers;
 
 use App\Core\Controller;
 use App\Core\Mailer;
-use App\Controllers\StatusController;
+use App\Services\StatusController;
 use App\Models\User;
 use App\Models\Feed;
 use App\Core\Csrf;

--- a/root/app/Services/StatusController.php
+++ b/root/app/Services/StatusController.php
@@ -12,7 +12,7 @@
  * Description: AI Social Status Generator
  */
 
-namespace App\Controllers;
+namespace App\Services;
 
 use App\Models\Account;
 use App\Models\User;

--- a/root/cron.php
+++ b/root/cron.php
@@ -23,7 +23,7 @@ require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/vendor/autoload.php';
 
 use App\Core\ErrorMiddleware;
-use App\Controllers\StatusController;
+use App\Services\StatusController;
 use App\Models\Account;
 use App\Models\User;
 use App\Models\Feed;


### PR DESCRIPTION
## Summary
- move `StatusController.php` to `app/Services`
- update namespace for `StatusController`
- reference new namespace in `HomeController` and `cron.php`

## Testing
- `composer validate --no-check-publish`
- `php -l app/Services/StatusController.php`
- `php -l app/Controllers/HomeController.php`
- `php -l cron.php`


------
https://chatgpt.com/codex/tasks/task_e_68846bedeab4832a8bf11fa62e57db9e