### PR TITLE
Refactor controllers to separate GET and POST handling

### DIFF
--- a/root/app/Controllers/AccountsController.php
+++ b/root/app/Controllers/AccountsController.php
@@ -24,25 +24,6 @@ class AccountsController extends Controller
 {
     public function handleRequest(): void
     {
-
-        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            if (!Csrf::validate($_POST['csrf_token'] ?? '')) {
-                $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
-                header('Location: /accounts');
-                exit;
-            }
-
-            if (isset($_POST['edit_account'])) {
-                self::createOrUpdateAccount();
-                return;
-            }
-
-            if (isset($_POST['delete_account'])) {
-                self::deleteAccount();
-                return;
-            }
-        }
-
         $daysOptions = self::generateDaysOptions();
         $cronOptions = self::generateCronOptions();
         $accountList = self::generateAccountList();
@@ -54,6 +35,28 @@ class AccountsController extends Controller
             'accountList' => $accountList,
             'calendarOverview' => $calendarOverview,
         ]);
+    }
+
+    public function handleSubmission(): void
+    {
+        if (!Csrf::validate($_POST['csrf_token'] ?? '')) {
+            $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
+            header('Location: /accounts');
+            exit;
+        }
+
+        if (isset($_POST['edit_account'])) {
+            self::createOrUpdateAccount();
+            return;
+        }
+
+        if (isset($_POST['delete_account'])) {
+            self::deleteAccount();
+            return;
+        }
+
+        header('Location: /accounts');
+        exit;
     }
 
     private static function createOrUpdateAccount(): void
@@ -154,7 +157,7 @@ class AccountsController extends Controller
     /**
      * Generate a calendar overview of scheduled posts grouped by day and time slot.
      */
-    public static function generateCalendarOverview(): string
+    private static function generateCalendarOverview(): string
     {
         $username = $_SESSION['username'];
         $accounts = User::getAllUserAccts($username);
@@ -243,7 +246,7 @@ class AccountsController extends Controller
         return $html;
     }
 
-    public static function generateDaysOptions(): string
+    private static function generateDaysOptions(): string
     {
         $days = ['everyday', 'sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
         $options = '';
@@ -253,7 +256,7 @@ class AccountsController extends Controller
         return $options;
     }
 
-    public static function generateCronOptions(): string
+    private static function generateCronOptions(): string
     {
         $options = '<option value="null" selected>Off</option>';
         for ($hour = 6; $hour <= 22; $hour++) {
@@ -266,7 +269,7 @@ class AccountsController extends Controller
         return $options;
     }
 
-    public static function generateAccountList(): string
+    private static function generateAccountList(): string
     {
         $username = $_SESSION['username'];
         $accounts = User::getAllUserAccts($username);

--- a/root/app/Controllers/HomeController.php
+++ b/root/app/Controllers/HomeController.php
@@ -26,23 +26,7 @@ class HomeController extends Controller
     public function handleRequest(): void
     {
 
-        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            if (!Csrf::validate($_POST['csrf_token'] ?? '')) {
-                $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
-                header('Location: /home');
-                exit;
-            }
 
-            if (isset($_POST['delete_status'])) {
-                self::deleteStatus();
-                return;
-            }
-
-            if (isset($_POST['generate_status'])) {
-                self::generateStatus();
-                return;
-            }
-        }
 
         $accountOwner = $_SESSION['username'];
         $accounts = \App\Models\Account::getAllUserAccts($accountOwner);
@@ -79,6 +63,28 @@ class HomeController extends Controller
             'accountOwner' => $accountOwner,
             'accountsData' => $accountsData,
         ]);
+    }
+
+    public function handleSubmission(): void
+    {
+        if (!Csrf::validate($_POST['csrf_token'] ?? '')) {
+            $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
+            header('Location: /home');
+            exit;
+        }
+
+        if (isset($_POST['delete_status'])) {
+            self::deleteStatus();
+            return;
+        }
+
+        if (isset($_POST['generate_status'])) {
+            self::generateStatus();
+            return;
+        }
+
+        header('Location: /home');
+        exit;
     }
 
 
@@ -152,7 +158,7 @@ class HomeController extends Controller
         header('Location: /home');
         exit;
     }
-    public static function shareButton(string $statusText, string $imagePath, string $accountOwner, string $accountName, int $statusId): string
+    private static function shareButton(string $statusText, string $imagePath, string $accountOwner, string $accountName, int $statusId): string
     {
         $filename = basename($imagePath);
         $imageUrl = DOMAIN . "/images/" . htmlspecialchars($accountOwner, ENT_QUOTES) . "/" . htmlspecialchars($accountName, ENT_QUOTES) . "/" . htmlspecialchars($filename, ENT_QUOTES);

--- a/root/app/Controllers/InfoController.php
+++ b/root/app/Controllers/InfoController.php
@@ -22,26 +22,6 @@ class InfoController extends Controller
 {
     public function handleRequest(): void
     {
-
-        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            $token = $_POST['csrf_token'] ?? '';
-            if (!Csrf::validate($token)) {
-                $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
-                header('Location: /info');
-                exit;
-            }
-
-            if (isset($_POST['change_password'])) {
-                self::processPasswordChange();
-                return;
-            }
-
-            if (isset($_POST['update_profile'])) {
-                self::processProfileUpdate();
-                return;
-            }
-        }
-
         $profileData = self::generateProfileDataAttributes($_SESSION['username']);
         $systemMsg = self::buildSystemMessage($_SESSION['username']);
 
@@ -49,6 +29,29 @@ class InfoController extends Controller
             'profileData' => $profileData,
             'systemMsg' => $systemMsg,
         ]);
+    }
+
+    public function handleSubmission(): void
+    {
+        $token = $_POST['csrf_token'] ?? '';
+        if (!Csrf::validate($token)) {
+            $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
+            header('Location: /info');
+            exit;
+        }
+
+        if (isset($_POST['change_password'])) {
+            self::processPasswordChange();
+            return;
+        }
+
+        if (isset($_POST['update_profile'])) {
+            self::processProfileUpdate();
+            return;
+        }
+
+        header('Location: /info');
+        exit;
     }
 
     private static function processPasswordChange(): void
@@ -105,7 +108,7 @@ class InfoController extends Controller
         exit;
     }
 
-    public static function generateProfileDataAttributes(string $username): string
+    private static function generateProfileDataAttributes(string $username): string
     {
         $userInfo = User::getUserInfo($username);
         if ($userInfo) {
@@ -118,7 +121,7 @@ class InfoController extends Controller
         return '';
     }
 
-    public static function buildSystemMessage(string $username): string
+    private static function buildSystemMessage(string $username): string
     {
         $userInfo = User::getUserInfo($username);
         if ($userInfo) {

--- a/root/app/Controllers/UsersController.php
+++ b/root/app/Controllers/UsersController.php
@@ -29,34 +29,44 @@ class UsersController extends Controller
             exit('Forbidden');
         }
 
-        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            if (!Csrf::validate($_POST['csrf_token'] ?? '')) {
-                $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
-                header('Location: /users');
-                exit;
-            }
-
-            if (isset($_POST['edit_users'])) {
-                self::editUsers();
-                return;
-            }
-
-            if (isset($_POST['delete_user']) && isset($_POST['username'])) {
-                self::deleteUser();
-                return;
-            }
-
-            if (isset($_POST['login_as']) && isset($_POST['username'])) {
-                self::loginAs();
-                return;
-            }
-        }
 
         $userList = self::generateUserList();
 
         $this->render('users', [
             'userList' => $userList,
         ]);
+    }
+
+    public function handleSubmission(): void
+    {
+        if (empty($_SESSION['is_admin'])) {
+            http_response_code(403);
+            exit('Forbidden');
+        }
+
+        if (!Csrf::validate($_POST['csrf_token'] ?? '')) {
+            $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
+            header('Location: /users');
+            exit;
+        }
+
+        if (isset($_POST['edit_users'])) {
+            self::editUsers();
+            return;
+        }
+
+        if (isset($_POST['delete_user']) && isset($_POST['username'])) {
+            self::deleteUser();
+            return;
+        }
+
+        if (isset($_POST['login_as']) && isset($_POST['username'])) {
+            self::loginAs();
+            return;
+        }
+
+        header('Location: /users');
+        exit;
     }
 
     private static function editUsers(): void
@@ -199,7 +209,7 @@ class UsersController extends Controller
         header('Location: /users');
         exit;
     }
-    public static function generateUserList(): string
+    private static function generateUserList(): string
     {
         $users = User::getAllUsers();
         $output = '';

--- a/root/app/Core/Router.php
+++ b/root/app/Core/Router.php
@@ -31,12 +31,21 @@ class Router
                 exit();
             });
 
-            // Register routes that should accept both GET and POST requests
-            $r->addRoute(['GET', 'POST'], '/login', [\App\Controllers\AuthController::class, 'handleRequest']);
-            $r->addRoute(['GET', 'POST'], '/accounts', [\App\Controllers\AccountsController::class, 'handleRequest']);
-            $r->addRoute(['GET', 'POST'], '/users', [\App\Controllers\UsersController::class, 'handleRequest']);
-            $r->addRoute(['GET', 'POST'], '/info', [\App\Controllers\InfoController::class, 'handleRequest']);
-            $r->addRoute(['GET', 'POST'], '/home', [\App\Controllers\HomeController::class, 'handleRequest']);
+            // Register routes for GET and POST requests separately
+            $r->addRoute('GET', '/login', [\App\Controllers\AuthController::class, 'handleRequest']);
+            $r->addRoute('POST', '/login', [\App\Controllers\AuthController::class, 'handleSubmission']);
+
+            $r->addRoute('GET', '/accounts', [\App\Controllers\AccountsController::class, 'handleRequest']);
+            $r->addRoute('POST', '/accounts', [\App\Controllers\AccountsController::class, 'handleSubmission']);
+
+            $r->addRoute('GET', '/users', [\App\Controllers\UsersController::class, 'handleRequest']);
+            $r->addRoute('POST', '/users', [\App\Controllers\UsersController::class, 'handleSubmission']);
+
+            $r->addRoute('GET', '/info', [\App\Controllers\InfoController::class, 'handleRequest']);
+            $r->addRoute('POST', '/info', [\App\Controllers\InfoController::class, 'handleSubmission']);
+
+            $r->addRoute('GET', '/home', [\App\Controllers\HomeController::class, 'handleRequest']);
+            $r->addRoute('POST', '/home', [\App\Controllers\HomeController::class, 'handleSubmission']);
 
             // Feed routes
             $r->addRoute('GET', '/feeds/{user}/{account}', [\App\Controllers\FeedController::class, 'handleRequest']);


### PR DESCRIPTION
## Summary
- split POST logic from controllers into new `handleSubmission()` methods
- register GET and POST routes separately in Router
- make internal helper methods private

## Testing
- `php -l root/app/Controllers/AccountsController.php`
- `php -l root/app/Controllers/AuthController.php`
- `php -l root/app/Controllers/HomeController.php`
- `php -l root/app/Controllers/InfoController.php`
- `php -l root/app/Controllers/UsersController.php`
- `php -l root/app/Core/Router.php`


------
https://chatgpt.com/codex/tasks/task_e_68846e85bd24832aa196a6b171c68261