### PR TITLE
Rename StatusController to StatusService

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,17 @@ Version 3.0.0 introduces improvements such as dedicated classes for all database
   with `httponly`, `secure`, and `SameSite=Lax` flags for better protection.
 - **IP Blacklisting:** Monitors and blacklists suspicious IP addresses to prevent brute-force attacks.
 - **Efficient Database Queries:** Uses optimized SQL queries and indexing to ensure fast data retrieval.
-- **Modular Classes:** Core logic is organized into classes such as Database, User, Account, StatusController, FeedController, and ErrorMiddleware for maintainability and scalability.
+- **Modular Classes:** Core logic is organized into classes such as Database, User, Account, StatusService, FeedController, and ErrorMiddleware for maintainability and scalability.
 
 
 ## Features
 
 |     |      Feature      | Summary |
 | :-- | :---------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ⚙️  | **Architecture**  | <ul><li>Modular structure with dedicated classes: <code>Database</code>, <code>User</code>, <code>Account</code>, <code>StatusController</code>, <code>FeedController</code>, and <code>ErrorMiddleware</code> (see <code>root/app/</code>).</li><li>Configuration centralized in <code>root/config.php</code>.</li><li>Autoloading handled by Composer via <code>vendor/autoload.php</code>.</li><li>Cron automation managed via <code>root/cron.php</code>.</li></ul> |
+| ⚙️  | **Architecture**  | <ul><li>Modular structure with dedicated classes: <code>Database</code>, <code>User</code>, <code>Account</code>, <code>StatusService</code>, <code>FeedController</code>, and <code>ErrorMiddleware</code> (see <code>root/app/</code>).</li><li>Configuration centralized in <code>root/config.php</code>.</li><li>Autoloading handled by Composer via <code>vendor/autoload.php</code>.</li><li>Cron automation managed via <code>root/cron.php</code>.</li></ul> |
 | 🔩  | **Code Quality**  | <ul><li>Follows PHP best practices and design patterns.</li><li>Centralized database operations using Doctrine DBAL in <code>Database.php</code>.</li><li>Robust error handling via <code>ErrorMiddleware.php</code>.</li><li>Clean inline documentation throughout core files.</li></ul> |
 | 📄  | **Documentation** | <ul><li>Includes install and usage steps.</li><li>Written in <code>PHP</code>, <code>SQL</code>, and <code>text</code> formats.</li><li>Simple onboarding for developers and admins.</li></ul> |
-| 🔌  | **Integrations**  | <ul><li>Posts to social platforms via <code>StatusController.php</code>.</li><li>Real-time RSS feed generation using <code>FeedController::outputRssFeed()</code>.</li><li>Secure login and session control via the MVC controllers.</li><li>Email notifications powered by PHPMailer with customizable templates.</li></ul> |
+| 🔌  | **Integrations**  | <ul><li>Posts to social platforms via <code>StatusService.php</code>.</li><li>Real-time RSS feed generation using <code>FeedController::outputRssFeed()</code>.</li><li>Secure login and session control via the MVC controllers.</li><li>Email notifications powered by PHPMailer with customizable templates.</li></ul> |
 | 🧩  |  **Modularity**   | <ul><li>All logic encapsulated in single-purpose classes.</li><li>Autoloading supports scalability and clean structure.</li><li>Code reuse across handlers and views.</li></ul> |
 | 🔒  |   **Security**    | <ul><li>Full CSRF protection on form actions.</li><li>Strict input validation and sanitization.</li><li>Session hardening and IP blacklisting to block abuse.</li></ul> |
                                                                                                                                                         |
@@ -198,7 +198,7 @@ The `db` service allows an empty MariaDB root password by setting `MARIADB_ALLOW
 - Moved RSS feed generation into `FeedController` and removed `rss-lib.php`.
 - Added type hints across the codebase and improved error propagation.
 - Improved error logging for RSS feed generation.
-- Refactored API interactions into `StatusController`.
+- Refactored API interactions into `StatusService`.
 - Various security fixes and bug improvements.
 
 ---

--- a/root/app/Controllers/HomeController.php
+++ b/root/app/Controllers/HomeController.php
@@ -16,7 +16,7 @@ namespace App\Controllers;
 
 use App\Core\Controller;
 use App\Core\Mailer;
-use App\Services\StatusController;
+use App\Services\StatusService;
 use App\Models\User;
 use App\Models\Feed;
 use App\Core\Csrf;
@@ -143,7 +143,7 @@ class HomeController extends Controller
                     User::setLimitEmailSent($accountOwner, true);
                 }
             } else {
-                $statusResult = StatusController::generateStatus($accountName, $accountOwner);
+                $statusResult = StatusService::generateStatus($accountName, $accountOwner);
                 if (isset($statusResult['error'])) {
                     $_SESSION['messages'][] = 'Failed to generate status: ' . $statusResult['error'];
                 } else {

--- a/root/app/Services/StatusService.php
+++ b/root/app/Services/StatusService.php
@@ -8,7 +8,7 @@
  * Link:    https://vontainment.com
  * Version: 3.0.0
  *
- * File: StatusController.php
+ * File: StatusService.php
  * Description: AI Social Status Generator
  */
 
@@ -19,7 +19,7 @@ use App\Models\User;
 use App\Models\Feed;
 use App\Core\ErrorMiddleware;
 
-class StatusController
+class StatusService
 {
     /**
      * Generates a status update and associated image for a given account.

--- a/root/cron.php
+++ b/root/cron.php
@@ -23,7 +23,7 @@ require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/vendor/autoload.php';
 
 use App\Core\ErrorMiddleware;
-use App\Services\StatusController;
+use App\Services\StatusService;
 use App\Models\Account;
 use App\Models\User;
 use App\Models\Feed;
@@ -195,7 +195,7 @@ function updateJobs(): bool
  */
 function processJob(object $job): void
 {
-    $result = StatusController::generateStatus($job->account, $job->username);
+    $result = StatusService::generateStatus($job->account, $job->username);
     if (isset($result['success'])) {
         JobQueue::markCompleted($job->id);
         


### PR DESCRIPTION
## Summary
- rename `StatusController` service to `StatusService`
- update references in Home controller and cron script
- update docs mentioning the service

## Testing
- `php -l root/app/Services/StatusService.php`
- `php -l root/app/Controllers/HomeController.php`
- `php -l root/cron.php`
- `composer dump-autoload`

------
https://chatgpt.com/codex/tasks/task_e_687db3c1a130832a8b046367847ba409