### PR TITLE
Fix image retention default

### DIFF
--- a/docker/docker-config.php
+++ b/docker/docker-config.php
@@ -40,7 +40,8 @@ define('MAX_WIDTH', getenv('MAX_WIDTH'));
 // Maximum number of statuses allowed in each feed
 define('MAX_STATUSES', getenv('MAX_STATUSES'));
 
-// Maximum age of images in days before they are removed (should be over 360 days)
+// Maximum age of images in days before they are removed. Default is
+// 360 days and production setups should keep it at least this value.
 define('IMG_AGE', getenv('IMG_AGE'));
 
 // Session timeout limit in seconds (default: 30 minutes)

--- a/root/config.php
+++ b/root/config.php
@@ -39,8 +39,9 @@ define('MAX_WIDTH', 720);
 // Maximum number of statuses allowed in each feed
 define('MAX_STATUSES', 8);
 
-// Maximum days to keep images. Should be over 360.
-define('IMG_AGE', 180);
+// Maximum days to keep images. Default is 360 and it should be kept at
+// least this value in production.
+define('IMG_AGE', 360);
 
 // Session timeout limit in seconds (default: 30 minutes)
 define('SESSION_TIMEOUT_LIMIT', 1800);


### PR DESCRIPTION
## Summary
- keep images for 360 days by default
- clarify comments about the recommended minimum age

## Testing
- `php -l root/config.php`
- `php -l docker/docker-config.php`


------
https://chatgpt.com/codex/tasks/task_e_688482d5abb8832aa26dfdb07c349d0b