### PR TITLE
Fix RSS image path sanitization

### DIFF
--- a/root/app/Controllers/FeedController.php
+++ b/root/app/Controllers/FeedController.php
@@ -133,10 +133,15 @@ class FeedController extends Controller
             // Include image enclosure if available
             if (!empty($status->status_image)) {
                 $imageUrl = DOMAIN . "/images/" . htmlspecialchars($accountOwner) . "/" . htmlspecialchars($status->account) . "/" . htmlspecialchars($status->status_image);
+
                 // Images are stored under root/public/images/<owner>/<account>/
-                $imageFilePath = __DIR__ . '/../../public/images/' . htmlspecialchars($accountOwner) . '/' . htmlspecialchars($status->account) . '/' . htmlspecialchars($status->status_image);
+                $pathOwner   = basename($accountOwner);
+                $pathAccount = basename($status->account);
+                $pathImage   = basename($status->status_image);
+
+                $imageFilePath = __DIR__ . '/../../public/images/' . $pathOwner . '/' . $pathAccount . '/' . $pathImage;
                 $imageFileSize = file_exists($imageFilePath) ? filesize($imageFilePath) : 0;
-                $enclosureTag = '<enclosure url="' . $imageUrl . '" length="' . $imageFileSize . '" type="image/png" />' . PHP_EOL;
+                $enclosureTag  = '<enclosure url="' . $imageUrl . '" length="' . $imageFileSize . '" type="image/png" />' . PHP_EOL;
             }
 
             $description = htmlspecialchars($status->status);


### PR DESCRIPTION
## Summary
- sanitize account, owner, and filename with `basename` before generating the RSS image enclosure path

## Testing
- `php -l root/app/Controllers/FeedController.php`
- `composer validate --no-check-all --strict`

------
https://chatgpt.com/codex/tasks/task_e_688482e0b0ec832ab36a895f7512db93