### PR TITLE
Fix license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,6 @@ The `db` service allows an empty MariaDB root password by setting `MARIADB_ALLOW
 
 ## 🎗 License
 
-This project is protected under the [MIT License](https://github.com/djav1985/v-chatgpt-editor/blob/main/LICENSE) License.
+This project is protected under the [MIT License](./LICENSE) License.
 
 ---


### PR DESCRIPTION
## Summary
- fix license hyperlink to reference repo's LICENSE file

## Testing
- `grep -n LICENSE -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_68848b02a2e0832a90e7d9e3a531b162