### PR TITLE
Update MAX_STATUSES default

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       DOMAIN: 'https://spectre3.hugev.xyz'
       SYSTEM_MSG: 'You are a social media marketer. You will respond with professional, fun, emoji loaded social status update and nothing else.'
       MAX_WIDTH: 720
-      MAX_STATUSES: 30
+      MAX_STATUSES: 50
       IMG_AGE: 360
       SESSION_TIMEOUT_LIMIT: 1800
       CRON_MAX_EXECUTION_TIME: 0

--- a/root/config.php
+++ b/root/config.php
@@ -37,7 +37,7 @@ define('SYSTEM_MSG', 'You are a social media marketer. You will respond with pro
 define('MAX_WIDTH', 720);
 
 // Maximum number of statuses allowed in each feed
-define('MAX_STATUSES', 30);
+define('MAX_STATUSES', 50);
 
 // Maximum days to keep images. Default is 360 and it should be kept at
 // least this value in production.


### PR DESCRIPTION
## Summary
- bump MAX_STATUSES to 50 in config and compose files

## Testing
- `php -l root/config.php`

------
https://chatgpt.com/codex/tasks/task_e_68856a6e480c832a9e4414043e621a58