### PR TITLE
Secure logout with CSRF token

### DIFF
--- a/root/app/Controllers/AuthController.php
+++ b/root/app/Controllers/AuthController.php
@@ -45,7 +45,13 @@ class AuthController extends Controller
     public function handleSubmission(): void
     {
         if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true && isset($_POST['logout'])) {
-            self::logoutUser();
+            if (Csrf::validate($_POST['csrf_token'] ?? '')) {
+                self::logoutUser();
+            } else {
+                $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
+                header('Location: /login');
+                exit();
+            }
         }
 
         if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true && !isset($_POST['logout'])) {


### PR DESCRIPTION
## Summary
- validate CSRF token before allowing logout

## Testing
- `composer install`
- `php -l app/Controllers/AuthController.php`


------
https://chatgpt.com/codex/tasks/task_e_688581b13404832a826d9450f14e37f3