### PR TITLE
Update README with SKIP LOCKED requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Before getting started with the installation, ensure your runtime environment me
 
 - **Web Server:** Apache
 - **Programming Language:** PHP 8.0+
-- **Database:** MySQL
+- **Database:** MySQL 8.0+ or compatible MariaDB
+  - Required for the `FOR UPDATE SKIP LOCKED` feature used by the queue to allow concurrent workers.
 
 ### ⚙️ Installation
 


### PR DESCRIPTION
## Summary
- document that MySQL 8.0 or compatible MariaDB is required
- explain why the queue needs `FOR UPDATE SKIP LOCKED`

## Testing
- `composer validate --no-check-all --strict`

------
https://chatgpt.com/codex/tasks/task_e_6886948ad060832ab71df2189592a0b6