### PR TITLE
cleanup: remove old queue settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Install the project using the following steps:
 3. **Update Configuration:**
 
    - Open `root/config.php` and update the necessary variables, including MySQL database credentials.
-   - Optionally adjust `CRON_MAX_EXECUTION_TIME`, `CRON_MEMORY_LIMIT`, and `CRON_QUEUE_LIMIT` to control how long the cron script runs, how much memory it can use, and how many queued jobs run each invocation.
+  - Optionally adjust `CRON_MAX_EXECUTION_TIME` and `CRON_MEMORY_LIMIT` to control how long the cron script runs and how much memory it can use.
 
 4. **Install Database:**
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,6 @@ RUN chown -R www-data:www-data /var/www && chmod -R 755 /var/www
 # Set up cron jobs
 RUN echo "0 0 * * * php /var/www/cron.php daily" >> /etc/crontab && \
     echo "0 * * * * php /var/www/cron.php hourly" >> /etc/crontab && \
-    echo "*/5 * * * * php /var/www/cron.php run_query" >> /etc/crontab && \
     crontab /etc/crontab
 
 

--- a/docker/docker-config.php
+++ b/docker/docker-config.php
@@ -53,7 +53,6 @@ define('DIR_MODE', 0755);
 // Cron runtime limits
 define('CRON_MAX_EXECUTION_TIME', getenv('CRON_MAX_EXECUTION_TIME') ?: 0);
 define('CRON_MEMORY_LIMIT', getenv('CRON_MEMORY_LIMIT') ?: '512M');
-define('CRON_QUEUE_LIMIT', getenv('CRON_QUEUE_LIMIT') ?: 10);
 
 // MySQL Database Connection Constants
 define('DB_HOST', getenv('DB_HOST'));

--- a/root/config.php
+++ b/root/config.php
@@ -52,7 +52,6 @@ define('DIR_MODE', 0755);
 // Cron runtime limits
 define('CRON_MAX_EXECUTION_TIME', getenv('CRON_MAX_EXECUTION_TIME') !== false ? getenv('CRON_MAX_EXECUTION_TIME') : 0);
 define('CRON_MEMORY_LIMIT', getenv('CRON_MEMORY_LIMIT') !== false ? getenv('CRON_MEMORY_LIMIT') : '512M');
-define('CRON_QUEUE_LIMIT', getenv('CRON_QUEUE_LIMIT') !== false ? (int) getenv('CRON_QUEUE_LIMIT') : 10);
 
 // MySQL Database Connection Constants
 define('DB_HOST', 'localhost'); // Database host or server


### PR DESCRIPTION
## Summary
- strip `CRON_QUEUE_LIMIT` from configs and docs
- drop unused `run_query` cronjob

## Testing
- `php -l root/config.php`
- `php -l docker/docker-config.php`
- `php -l docker/Dockerfile`
- `php -l root/cron.php`
- `composer validate --no-check-publish`

------
https://chatgpt.com/codex/tasks/task_e_6886a5a8bbe0832a9ad7e7903a86a3a8