### PR TITLE
Move cron tasks to dedicated service

### DIFF
--- a/root/app/Services/CronService.php
+++ b/root/app/Services/CronService.php
@@ -1,0 +1,107 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+
+/**
+ * Project: SocialRSS
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: CronService.php
+ * Description: Maintenance tasks for the cron script
+ */
+
+namespace App\Services;
+
+use RecursiveIteratorIterator;
+use RecursiveDirectoryIterator;
+use App\Models\Account;
+use App\Models\User;
+use App\Models\Feed;
+use App\Core\Mailer;
+use App\Models\Security;
+
+class CronService
+{
+    /**
+     * Clean up old statuses for all accounts.
+     */
+    public function purgeStatuses(): bool
+    {
+        $accounts = Account::getAllAccounts();
+        if (empty($accounts)) {
+            return true;
+        }
+
+        foreach ($accounts as $account) {
+            $accountName = $account->account;
+            $accountOwner = $account->username;
+            $statusCount = Feed::countStatuses($accountName, $accountOwner);
+
+            if ($statusCount > MAX_STATUSES) {
+                $deleteCount = $statusCount - MAX_STATUSES;
+                if (!Feed::deleteOldStatuses($accountName, $accountOwner, $deleteCount)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Purge old images from the public/images directory.
+     */
+    public function purgeImages(): bool
+    {
+        $imageDir = __DIR__ . '/../../public/images/';
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($imageDir, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        $now = time();
+
+        foreach ($files as $fileinfo) {
+            if ($fileinfo->isFile() && $fileinfo->getExtension() == 'png') {
+                $filePath = $fileinfo->getRealPath();
+                $fileAge = ($now - $fileinfo->getMTime()) / 86400;
+
+                if ($fileAge > IMG_AGE) {
+                    if (!unlink($filePath)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Reset API usage for all users.
+     */
+    public function resetApi(): bool
+    {
+        if (!User::resetAllApiUsage()) {
+            return false;
+        }
+        $users = User::getAllUsers();
+        foreach ($users as $user) {
+            Mailer::sendTemplate(
+                $user->email,
+                'API Usage Reset',
+                'api_usage_reset',
+                ['username' => $user->username]
+            );
+        }
+        return true;
+    }
+
+    /**
+     * Purge old entries from the IP blacklist.
+     */
+    public function purgeIps(): bool
+    {
+        return Security::clearIpBlacklist();
+    }
+}

--- a/root/cron.php
+++ b/root/cron.php
@@ -24,11 +24,8 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 use App\Core\ErrorMiddleware;
 use App\Services\QueueService;
+use App\Services\CronService;
 use App\Models\Account;
-use App\Models\User;
-use App\Models\Feed;
-use App\Core\Mailer;
-use App\Models\Security;
 
 // Apply configured runtime limits after loading settings
 ini_set('max_execution_time', (string) (defined('CRON_MAX_EXECUTION_TIME') ? CRON_MAX_EXECUTION_TIME : 0));
@@ -37,6 +34,7 @@ ini_set('memory_limit', defined('CRON_MEMORY_LIMIT') ? CRON_MEMORY_LIMIT : '512M
 // Run the job logic within the error middleware handler
 ErrorMiddleware::handle(function () {
     global $argv;
+    $service = new CronService();
 
 $validJobTypes = [
     'daily',
@@ -53,17 +51,17 @@ switch ($jobType) {
     case 'daily': {
         $resetOk = true;
         if (date('j') === '1') {
-            $resetOk = resetApi();
+            $resetOk = $service->resetApi();
         }
-        $purgeIpsOk = purgeIps();
+        $purgeIpsOk = $service->purgeIps();
         if ((date('j') === '1' && !$resetOk) || !$purgeIpsOk) {
             die(1);
         }
         break;
     }
     case 'hourly': {
-        $statusOk = purgeStatuses();
-        $imagesOk = purgeImages();
+        $statusOk = $service->purgeStatuses();
+        $imagesOk = $service->purgeImages();
         if (!$statusOk || !$imagesOk) {
             die(1);
         }
@@ -90,101 +88,3 @@ switch ($jobType) {
         die(1);
 }
 });
-
-
-/**
- * Clean up old statuses for all accounts.
- * This function checks the number of statuses for each account and deletes the oldest ones if they exceed the maximum allowed.
- * This helps to manage storage and keep the database performant.
- */
-function purgeStatuses(): bool
-{
-    $accounts = Account::getAllAccounts();
-    if (empty($accounts)) {
-        return true; // Return true as this is not necessarily an error condition
-    }
-
-    foreach ($accounts as $account) {
-        $accountName = $account->account;
-        $accountOwner = $account->username;
-        $statusCount = Feed::countStatuses($accountName, $accountOwner);
-
-        if ($statusCount > MAX_STATUSES) {
-            $deleteCount = $statusCount - MAX_STATUSES;
-            if (!Feed::deleteOldStatuses($accountName, $accountOwner, $deleteCount)) {
-                
-                return false;
-            }
-        }
-    }
-    return true;
-}
-
-/**
- * Purge old images from the public/images directory.
- * This function deletes image files that are older than the defined image age.
- * This helps to free up disk space and remove potentially outdated or unused images.
- */
-function purgeImages(): bool
-{
-    $imageDir = __DIR__ . '/public/images/';
-    $files = new RecursiveIteratorIterator(
-        new RecursiveDirectoryIterator($imageDir, RecursiveDirectoryIterator::SKIP_DOTS),
-        RecursiveIteratorIterator::CHILD_FIRST
-    );
-
-    $now = time();
-
-    foreach ($files as $fileinfo) {
-        if ($fileinfo->isFile() && $fileinfo->getExtension() == 'png') {
-            $filePath = $fileinfo->getRealPath();
-            $fileAge = ($now - $fileinfo->getMTime()) / 86400;
-
-            if ($fileAge > IMG_AGE) {
-                if (!unlink($filePath)) {
-                    
-                    return false;
-                }
-            }
-        }
-    }
-    return true;
-}
-
-/**
- * Reset API usage for all users.
- * This function resets the API usage count for all users to zero.
- * This is typically run at the start of a new billing cycle.
- */
-function resetApi(): bool
-{
-    if (!User::resetAllApiUsage()) {
-        
-        return false;
-    }
-    $users = User::getAllUsers();
-    foreach ($users as $user) {
-        Mailer::sendTemplate(
-            $user->email,
-            'API Usage Reset',
-            'api_usage_reset',
-            ['username' => $user->username]
-        );
-    }
-    return true;
-}
-
-/**
- * Purge old entries from the IP blacklist.
- * This function calls Security::clearIpBlacklist() to remove expired IP addresses.
- * Schedule periodically so the blacklist does not grow indefinitely.
- */
-function purgeIps(): bool
-{
-    return Security::clearIpBlacklist();
-}
-
-
-/**
- * Run queued jobs and generate statuses.
- */


### PR DESCRIPTION
## Summary
- add `CronService` class for maintenance tasks
- use `CronService` from `cron.php`
- remove old standalone functions

## Testing
- `composer validate --no-check-all`
- `php -l cron.php`
- `php -l app/Services/CronService.php`


------
https://chatgpt.com/codex/tasks/task_e_6886ab1b6a7c832a88db46874dd9b2f8