### PR TITLE
Fix CronService Security reference

### DIFF
--- a/root/app/Services/CronService.php
+++ b/root/app/Services/CronService.php
@@ -20,7 +20,7 @@ use App\Models\Account;
 use App\Models\User;
 use App\Models\Feed;
 use App\Core\Mailer;
-use App\Models\Security;
+use App\Services\SecurityService;
 
 class CronService
 {
@@ -102,6 +102,6 @@ class CronService
      */
     public function purgeIps(): bool
     {
-        return Security::clearIpBlacklist();
+        return SecurityService::clearIpBlacklist();
     }
 }


### PR DESCRIPTION
## Summary
- use SecurityService directly in CronService instead of alias

## Testing
- `php -l root/app/Services/CronService.php`


------
https://chatgpt.com/codex/tasks/task_e_6886ad616a84832abb0118beb1ece41a