### PR TITLE
Switch to OpenAI client & Respect Validation

### DIFF
--- a/root/app/Controllers/AccountsController.php
+++ b/root/app/Controllers/AccountsController.php
@@ -18,6 +18,7 @@ use App\Core\Controller;
 use App\Models\Account;
 use App\Models\User;
 use App\Core\Csrf;
+use Respect\Validation\Validator;
 
 class AccountsController extends Controller
 {
@@ -113,10 +114,10 @@ class AccountsController extends Controller
         if (empty($prompt)) {
             $_SESSION['messages'][] = 'Missing required field(s).';
         }
-        if (!preg_match('/^[a-z0-9-]{8,18}$/', $accountName)) {
+        if (!Validator::alnum('-')->noWhitespace()->lowercase()->length(8, 18)->validate($accountName)) {
             $_SESSION['messages'][] = 'Account name must be 8-18 characters long, alphanumeric and hyphens only.';
         }
-        if (!filter_var($link, FILTER_VALIDATE_URL)) {
+        if (!Validator::url()->startsWith('https://')->validate($link)) {
             $_SESSION['messages'][] = 'Link must be a valid URL starting with https://.';
         }
 

--- a/root/app/Controllers/InfoController.php
+++ b/root/app/Controllers/InfoController.php
@@ -17,6 +17,7 @@ namespace App\Controllers;
 use App\Core\Controller;
 use App\Models\User;
 use App\Core\Csrf;
+use Respect\Validation\Validator;
 
 class InfoController extends Controller
 {
@@ -79,7 +80,7 @@ class InfoController extends Controller
             $_SESSION['messages'][] = 'Passwords do not match. Please try again.';
         }
 
-        if (!preg_match('/^(?=.*[A-Za-z])(?=.*\d)(?=.*[\W_]).{8,16}$/', $password)) {
+        if (!Validator::regex('/^(?=.*[A-Za-z])(?=.*\d)(?=.*[\W_]).{8,16}$/')->validate($password)) {
             $_SESSION['messages'][] = 'Password must be 8-16 characters long, including at least one letter, one number, and one symbol.';
         }
 

--- a/root/app/Controllers/UsersController.php
+++ b/root/app/Controllers/UsersController.php
@@ -18,6 +18,7 @@ use App\Core\Controller;
 use App\Core\Mailer;
 use App\Models\User;
 use App\Core\Csrf;
+use Respect\Validation\Validator;
 
 class UsersController extends Controller
 {
@@ -96,13 +97,13 @@ class UsersController extends Controller
         $expires = trim($_POST['expires']);
         $admin = intval($_POST['admin']);
 
-        if (!preg_match('/^[a-z0-9]{5,16}$/', $username)) {
+        if (!Validator::alnum()->noWhitespace()->lowercase()->length(5, 16)->validate($username)) {
             $_SESSION['messages'][] = 'Username must be 5-16 characters long, lowercase letters and numbers only.';
         }
-        if (!empty($password) && !preg_match('/^(?=.*[A-Za-z])(?=.*\d)(?=.*[\W_]).{8,16}$/', $password)) {
+        if (!empty($password) && !Validator::regex('/^(?=.*[A-Za-z])(?=.*\d)(?=.*[\W_]).{8,16}$/')->validate($password)) {
             $_SESSION['messages'][] = 'Password must be 8-16 characters long, including at least one letter, one number, and one symbol.';
         }
-        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        if (!Validator::email()->validate($email)) {
             $_SESSION['messages'][] = 'Please provide a valid email address.';
         }
 


### PR DESCRIPTION
## Summary
- replace manual cURL requests with `openai-php/client`
- validate user input using `respect/validation`
- remove alias `v` for Validator for clarity

## Testing
- `php -l root/app/Services/StatusService.php`
- `php -l root/app/Controllers/UsersController.php`
- `php -l root/app/Controllers/AccountsController.php`
- `php -l root/app/Controllers/InfoController.php`


------
https://chatgpt.com/codex/tasks/task_e_6886d39b95fc832a8fcf83f188bcf6f3