### PR TITLE
refactor: introduce Database singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@
 I. [ Overview](#-overview)
 II. [ Features](#-features)
 III. [ Project Structure](#-project-structure)
-IV. [ Getting Started](#-getting-started)
-V. [ Docker](#docker)
-VI. [ Changelog](#-changelog)
-VII. [ License](#-license)
+IV. [ Usage](#usage)
+V. [ Getting Started](#-getting-started)
+VI. [ Docker](#docker)
+VII. [ Changelog](#-changelog)
+VIII. [ License](#-license)
 
 ---
 
@@ -81,6 +82,16 @@ Version 3.0.0 introduces improvements such as dedicated classes for all database
             └── install.php
 ```
 The code under `root/app` follows an MVC pattern with `Controllers`, `Models`, and `Views`. Shared framework classes live in the `Core` directory.
+
+## Usage
+
+To access the database connection within the application, retrieve the singleton instance of the `Database` class:
+
+```php
+use App\Core\Database;
+
+$db = Database::getInstance();
+```
 
 ---
 

--- a/root/app/Core/Database.php
+++ b/root/app/Core/Database.php
@@ -24,6 +24,7 @@ use App\Core\ErrorMiddleware;
 
 class Database
 {
+    private static ?Database $instance = null;
     private static ?Connection $dbh = null;
     private static ?int $lastUsedTime = null;
     private static int $idleTimeout = 10;
@@ -39,9 +40,22 @@ class Database
      *
      * @return void
      */
-    public function __construct()
+    private function __construct()
     {
         $this->connect();
+    }
+
+    /**
+     * Get the singleton Database instance.
+     *
+     * @return Database
+     */
+    public static function getInstance(): Database
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+        return self::$instance;
     }
 
     /**

--- a/root/app/Models/Account.php
+++ b/root/app/Models/Account.php
@@ -28,7 +28,7 @@ class Account
     public static function getAllAccounts(): array
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("SELECT * FROM accounts");
             return $db->resultSet();
         } catch (Exception $e) {
@@ -46,7 +46,7 @@ class Account
     public static function getAllUserAccts(string $username): array
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("SELECT account FROM accounts WHERE username = :username");
             $db->bind(':username', $username);
             return $db->resultSet();
@@ -66,7 +66,7 @@ class Account
     public static function accountExists(string $accountOwner, string $accountName): bool
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("SELECT 1 FROM accounts WHERE username = :accountOwner AND account = :accountName LIMIT 1");
             $db->bind(':accountOwner', $accountOwner);
             $db->bind(':accountName', $accountName);
@@ -87,7 +87,7 @@ class Account
     public static function getAcctInfo(string $username, string $account): mixed
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("SELECT * FROM accounts WHERE username = :username AND account = :account");
             $db->bind(':username', $username);
             $db->bind(':account', $account);
@@ -108,7 +108,7 @@ class Account
     public static function getAccountLink(string $username, string $account): string
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("SELECT link FROM accounts WHERE username = :username AND account = :account");
             $db->bind(':username', $username);
             $db->bind(':account', $account);
@@ -135,7 +135,7 @@ class Account
      */
     public static function updateAccount(string $accountOwner, string $accountName, string $prompt, string $platform, int $hashtags, string $link, string $cron, string $days): bool
     {
-        $db = new Database();
+        $db = Database::getInstance();
         $db->beginTransaction();
         try {
             $db->query("SELECT cron, days FROM accounts WHERE username = :accountOwner AND account = :accountName FOR UPDATE");
@@ -180,7 +180,7 @@ class Account
      */
     public static function createAccount(string $accountOwner, string $accountName, string $prompt, string $platform, int $hashtags, string $link, string $cron, string $days): bool
     {
-        $db = new Database();
+        $db = Database::getInstance();
         $db->beginTransaction();
         try {
             $db->query("INSERT INTO accounts (username, account, prompt, platform, hashtags, link, cron, days) VALUES (:accountOwner, :accountName, :prompt, :platform, :hashtags, :link, :cron, :days)");
@@ -211,7 +211,7 @@ class Account
      */
     public static function deleteAccount(string $accountOwner, string $accountName): bool
     {
-        $db = new Database();
+        $db = Database::getInstance();
         $db->beginTransaction();
         try {
             $db->query("DELETE FROM status_updates WHERE username = :accountOwner AND account = :accountName");

--- a/root/app/Models/Feed.php
+++ b/root/app/Models/Feed.php
@@ -32,7 +32,7 @@ class Feed
     public static function getStatusImagePath(int $statusId, string $accountName, string $accountOwner): ?string
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("SELECT status_image FROM status_updates WHERE id = :statusId AND account = :account AND username = :username");
             $db->bind(':statusId', $statusId);
             $db->bind(':account', $accountName);
@@ -56,7 +56,7 @@ class Feed
     public static function deleteStatus(int $statusId, string $accountName, string $accountOwner): bool
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("DELETE FROM status_updates WHERE id = :statusId AND account = :account AND username = :username");
             $db->bind(':statusId', $statusId);
             $db->bind(':account', $accountName);
@@ -79,7 +79,7 @@ class Feed
     public static function getStatusInfo(string $username, string $account): array
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("SELECT * FROM status_updates WHERE username = :username AND account = :account ORDER BY created_at DESC");
             $db->bind(':username', $username);
             $db->bind(':account', $account);
@@ -102,7 +102,7 @@ class Feed
     public static function saveStatus(string $accountName, string $accountOwner, string $status_content, string $image_name): bool
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $sql = "INSERT INTO status_updates (username, account, status, created_at, status_image) VALUES (:username, :account, :status, NOW(), :status_image)";
             $db->query($sql);
             $db->bind(':username', $accountOwner);
@@ -127,7 +127,7 @@ class Feed
     public static function getStatusUpdates(string $username, string $account): array
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("SELECT * FROM status_updates WHERE account = :accountName AND username = :accountOwner ORDER BY created_at DESC");
             $db->bind(':accountName', $account);
             $db->bind(':accountOwner', $username);
@@ -147,7 +147,7 @@ class Feed
     public static function countStatuses(string $accountName, string $accountOwner): int
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("SELECT COUNT(*) as count FROM status_updates WHERE account = :account AND username = :username");
             $db->bind(':account', $accountName);
             $db->bind(':username', $accountOwner);
@@ -169,7 +169,7 @@ class Feed
     public static function deleteOldStatuses(string $accountName, string $accountOwner, int $deleteCount): bool
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("DELETE FROM status_updates WHERE account = :account AND username = :username ORDER BY created_at ASC LIMIT :deleteCount");
             $db->bind(':account', $accountName);
             $db->bind(':username', $accountOwner);
@@ -193,7 +193,7 @@ class Feed
     public static function hasStatusBeenPosted(string $accountName, string $accountOwner, string $hour): bool
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $start = date('Y-m-d ') . sprintf('%02d', $hour) . ':00:00';
             $end = date('Y-m-d ') . sprintf('%02d', $hour) . ':59:59';
 
@@ -220,7 +220,7 @@ class Feed
     public static function getLatestStatusUpdate(string $accountName, string $accountOwner): ?object
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("SELECT * FROM status_updates WHERE account = :account AND username = :username ORDER BY created_at DESC LIMIT 1");
             $db->bind(':account', $accountName);
             $db->bind(':username', $accountOwner);

--- a/root/app/Models/User.php
+++ b/root/app/Models/User.php
@@ -28,7 +28,7 @@ class User
     public static function getAllUsers(): array
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("SELECT * FROM users");
             return $db->resultSet();
         } catch (Exception $e) {
@@ -46,7 +46,7 @@ class User
     public static function userExists(string $username): ?object
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("SELECT * FROM users WHERE username = :username");
             $db->bind(':username', $username);
             $result = $db->single();
@@ -73,7 +73,7 @@ class User
      */
     public static function updateUser(string $username, string $password, string $email, int $totalAccounts, int $maxApiCalls, int $usedApiCalls, string $expires, int $admin, bool $isUpdate): bool
     {
-        $db = new Database();
+        $db = Database::getInstance();
         $db->beginTransaction();
         try {
             if ($isUpdate) {
@@ -107,7 +107,7 @@ class User
      */
     public static function deleteUser(string $username): bool
     {
-        $db = new Database();
+        $db = Database::getInstance();
         $db->beginTransaction();
         try {
             $db->query("DELETE FROM users WHERE username = :username");
@@ -141,7 +141,7 @@ class User
     public static function updatePassword(string $username, string $hashedPassword): bool
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("UPDATE users SET password = :password WHERE username = :username");
             $db->bind(':username', $username);
             $db->bind(':password', $hashedPassword);
@@ -162,7 +162,7 @@ class User
     public static function getUserInfo(string $username): mixed
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("SELECT * FROM users WHERE username = :username");
             $db->bind(':username', $username);
             return $db->single();
@@ -181,7 +181,7 @@ class User
     public static function getAllUserAccts(string $username): array
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("SELECT * FROM accounts WHERE username = :username");
             $db->bind(':username', $username);
             return $db->resultSet();
@@ -201,7 +201,7 @@ class User
     public static function updateUsedApiCalls(string $username, int $usedApiCalls): bool
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("UPDATE users SET used_api_calls = :used_api_calls WHERE username = :username");
             $db->bind(':used_api_calls', $usedApiCalls);
             $db->bind(':username', $username);
@@ -223,7 +223,7 @@ class User
     public static function updateMaxApiCalls(string $username, int $maxApiCalls): bool
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("UPDATE users SET max_api_calls = :max_api_calls WHERE username = :username");
             $db->bind(':max_api_calls', $maxApiCalls);
             $db->bind(':username', $username);
@@ -241,7 +241,7 @@ class User
     public static function setLimitEmailSent(string $username, bool $sent): bool
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("UPDATE users SET limit_email_sent = :sent WHERE username = :username");
             $db->bind(':sent', $sent ? 1 : 0);
             $db->bind(':username', $username);
@@ -261,7 +261,7 @@ class User
     public static function resetAllApiUsage(): bool
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("UPDATE users SET used_api_calls = 0, limit_email_sent = 0");
             $db->execute();
             return true;
@@ -284,7 +284,7 @@ class User
     public static function updateProfile(string $username, string $who, string $where, string $what, string $goal): bool
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("UPDATE users SET who = :who, `where` = :where, what = :what, goal = :goal WHERE username = :username");
             $db->bind(':username', $username);
             $db->bind(':who', $who);

--- a/root/app/Services/SecurityService.php
+++ b/root/app/Services/SecurityService.php
@@ -26,7 +26,7 @@ class SecurityService
     public static function updateFailedAttempts(string $ip): void
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("SELECT * FROM ip_blacklist WHERE ip_address = :ip");
             $db->bind(':ip', $ip);
             $result = $db->single();
@@ -58,7 +58,7 @@ class SecurityService
     public static function isBlacklisted(string $ip): bool
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $db->query("SELECT * FROM ip_blacklist WHERE ip_address = :ip AND blacklisted = TRUE");
             $db->bind(':ip', $ip);
             $result = $db->single();
@@ -87,7 +87,7 @@ class SecurityService
     public static function clearIpBlacklist(): bool
     {
         try {
-            $db = new Database();
+            $db = Database::getInstance();
             $threeDaysAgo = time() - (3 * 24 * 60 * 60);
             $db->query("DELETE FROM ip_blacklist WHERE timestamp < :threeDaysAgo");
             $db->bind(':threeDaysAgo', $threeDaysAgo);


### PR DESCRIPTION
## Summary
- convert `Database` into a singleton with `getInstance`
- update models and services to use the singleton
- document database usage in README

## Testing
- `php -l root/app/Core/Database.php root/app/Models/Account.php root/app/Models/Feed.php root/app/Models/User.php root/app/Services/SecurityService.php`


------
https://chatgpt.com/codex/tasks/task_e_68998aa27870832ab19482af27198f53