### PR TITLE
Introduce SessionManager and centralize session handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,22 @@ use App\Core\Database;
 $db = Database::getInstance();
 ```
 
+### Session Management
+
+Manage sessions through the `SessionManager` singleton:
+
+```php
+use App\Core\SessionManager;
+
+$session = SessionManager::getInstance();
+$session->start();           // Start or resume a session
+$session->set('name', 'value');
+$value = $session->get('name');
+$session->regenerate();      // Regenerate ID after login
+```
+
+Call `$session->destroy();` to end the session during logout.
+
 ---
 
 ## 🚀 Getting Started

--- a/root/app/Controllers/AuthController.php
+++ b/root/app/Controllers/AuthController.php
@@ -19,6 +19,7 @@ use App\Services\SecurityService;
 use App\Core\ErrorHandler;
 use App\Core\Controller;
 use App\Core\Csrf;
+use App\Core\SessionManager;
 
 class AuthController extends Controller
 {
@@ -29,7 +30,8 @@ class AuthController extends Controller
      */
     public function handleRequest(): void
     {
-        if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true) {
+        $session = SessionManager::getInstance();
+        if ($session->get('logged_in') === true) {
             header('Location: /');
             exit();
         }
@@ -44,17 +46,20 @@ class AuthController extends Controller
      */
     public function handleSubmission(): void
     {
-        if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true && isset($_POST['logout'])) {
+        $session = SessionManager::getInstance();
+        if ($session->get('logged_in') === true && isset($_POST['logout'])) {
             if (Csrf::validate($_POST['csrf_token'] ?? '')) {
                 self::logoutUser();
             } else {
-                $_SESSION['messages'][] = 'Invalid CSRF token. Please try again.';
+                $messages = $session->get('messages', []);
+                $messages[] = 'Invalid CSRF token. Please try again.';
+                $session->set('messages', $messages);
                 header('Location: /login');
                 exit();
             }
         }
 
-        if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true && !isset($_POST['logout'])) {
+        if ($session->get('logged_in') === true && !isset($_POST['logout'])) {
             header('Location: /');
             exit();
         }
@@ -62,20 +67,22 @@ class AuthController extends Controller
         if (!Csrf::validate($_POST['csrf_token'] ?? '')) {
             $error = 'Invalid CSRF token. Please try again.';
             ErrorHandler::getInstance()->log($error);
-            $_SESSION['messages'][] = $error;
+            $messages = $session->get('messages', []);
+            $messages[] = $error;
+            $session->set('messages', $messages);
         } else {
             $username = trim($_POST['username'] ?? '');
             $password = trim($_POST['password'] ?? '');
             $userInfo = self::validateCredentials($username, $password);
 
             if ($userInfo) {
-                $_SESSION['logged_in'] = true;
-                $_SESSION['username'] = $userInfo->username;
-                $_SESSION['user_agent'] = $_SERVER['HTTP_USER_AGENT'];
-                $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
-                $_SESSION['is_admin'] = $userInfo->admin;
-                $_SESSION['timeout'] = time();
-                session_regenerate_id(true);
+                $session->set('logged_in', true);
+                $session->set('username', $userInfo->username);
+                $session->set('user_agent', $_SERVER['HTTP_USER_AGENT']);
+                $session->set('csrf_token', bin2hex(random_bytes(32)));
+                $session->set('is_admin', $userInfo->admin);
+                $session->set('timeout', time());
+                $session->regenerate();
                 header('Location: /');
                 exit();
             }
@@ -84,12 +91,16 @@ class AuthController extends Controller
             if (SecurityService::isBlacklisted($ip)) {
                 $error = 'Your IP has been blacklisted due to multiple failed login attempts.';
                 ErrorHandler::getInstance()->log($error);
-                $_SESSION['messages'][] = $error;
+                $messages = $session->get('messages', []);
+                $messages[] = $error;
+                $session->set('messages', $messages);
             } else {
                 SecurityService::updateFailedAttempts($ip);
                 $error = 'Invalid username or password.';
                 ErrorHandler::getInstance()->log($error);
-                $_SESSION['messages'][] = $error;
+                $messages = $session->get('messages', []);
+                $messages[] = $error;
+                $session->set('messages', $messages);
             }
         }
 
@@ -103,8 +114,7 @@ class AuthController extends Controller
      */
     private static function logoutUser(): void
     {
-        unset($_SESSION['is_admin']);
-        session_destroy();
+        SessionManager::getInstance()->destroy();
         header('Location: /login');
         exit();
     }

--- a/root/app/Core/AuthMiddleware.php
+++ b/root/app/Core/AuthMiddleware.php
@@ -34,21 +34,23 @@ class AuthMiddleware
             exit();
         }
 
-        if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+        $session = SessionManager::getInstance();
+        if (!$session->get('logged_in')) {
             header('Location: /login');
             exit();
         }
 
         $timeoutLimit = defined('SESSION_TIMEOUT_LIMIT') ? SESSION_TIMEOUT_LIMIT : 1800;
-        $timeoutExceeded = isset($_SESSION['timeout']) && (time() - $_SESSION['timeout'] > $timeoutLimit);
-        $userAgentChanged = isset($_SESSION['user_agent']) && $_SESSION['user_agent'] !== ($_SERVER['HTTP_USER_AGENT'] ?? '');
+        $timeout = $session->get('timeout');
+        $timeoutExceeded = is_int($timeout) && (time() - $timeout > $timeoutLimit);
+        $userAgent = $session->get('user_agent');
+        $userAgentChanged = is_string($userAgent) && $userAgent !== ($_SERVER['HTTP_USER_AGENT'] ?? '');
         if ($timeoutExceeded || $userAgentChanged) {
-            session_unset();
-            session_destroy();
+            $session->destroy();
             header('Location: /login');
             exit();
         }
 
-        $_SESSION['timeout'] = time();
+        $session->set('timeout', time());
     }
 }

--- a/root/app/Core/Csrf.php
+++ b/root/app/Core/Csrf.php
@@ -24,6 +24,7 @@ class Csrf
      */
     public static function validate(string $token): bool
     {
-        return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
+        $sessionToken = SessionManager::getInstance()->get('csrf_token');
+        return is_string($sessionToken) && hash_equals($sessionToken, $token);
     }
 }

--- a/root/app/Core/ErrorMiddleware.php
+++ b/root/app/Core/ErrorMiddleware.php
@@ -114,11 +114,13 @@ class ErrorMiddleware
      */
     public static function displayAndClearMessages(): void
     {
-        if (isset($_SESSION['messages']) && count($_SESSION['messages']) > 0) {
-            foreach ($_SESSION['messages'] as $message) {
+        $session = SessionManager::getInstance();
+        $messages = $session->get('messages', []);
+        if (!empty($messages)) {
+            foreach ($messages as $message) {
                 echo '<script>showToast(' . json_encode($message) . ');</script>';
             }
-            unset($_SESSION['messages']);
+            $session->set('messages', []);
         }
     }
 }

--- a/root/app/Core/SessionManager.php
+++ b/root/app/Core/SessionManager.php
@@ -1,0 +1,112 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+
+/**
+ * Project: SocialRSS
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: SessionManager.php
+ * Description: Centralized session management
+ */
+
+namespace App\Core;
+
+class SessionManager
+{
+    /**
+     * Singleton instance of the SessionManager.
+     */
+    private static ?SessionManager $instance = null;
+
+    /**
+     * Private constructor to prevent direct instantiation.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Retrieve the singleton instance.
+     *
+     * @return SessionManager
+     */
+    public static function getInstance(): SessionManager
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Start the session with secure cookie parameters.
+     *
+     * @return void
+     */
+    public function start(): void
+    {
+        $secureFlag = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
+        session_set_cookie_params([
+            'path'     => '/',
+            'httponly' => true,
+            'secure'   => $secureFlag,
+            'samesite' => 'Lax',
+        ]);
+
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+    }
+
+    /**
+     * Destroy the current session and its data.
+     *
+     * @return void
+     */
+    public function destroy(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            $_SESSION = [];
+            session_destroy();
+        }
+    }
+
+    /**
+     * Regenerate the session ID to prevent fixation.
+     *
+     * @return void
+     */
+    public function regenerate(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_regenerate_id(true);
+        }
+    }
+
+    /**
+     * Retrieve a value from the session.
+     *
+     * @param string $key     Session key to retrieve.
+     * @param mixed  $default Default value if key does not exist.
+     * @return mixed
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $_SESSION[$key] ?? $default;
+    }
+
+    /**
+     * Set a session value.
+     *
+     * @param string $key   Session key to set.
+     * @param mixed  $value Value to store.
+     * @return void
+     */
+    public function set(string $key, mixed $value): void
+    {
+        $_SESSION[$key] = $value;
+    }
+}

--- a/root/app/Views/accounts.php
+++ b/root/app/Views/accounts.php
@@ -59,8 +59,7 @@ require 'partials/header.php';
                     <option value="0" selected>No</option>
                     <option value="1">Yes</option>
                 </select>
-                <input type="hidden" name="csrf_token" value="<?php
- echo $_SESSION['csrf_token']; ?>">
+                <input type="hidden" name="csrf_token" value="<?php echo App\Core\SessionManager::getInstance()->get('csrf_token'); ?>">
                 <button type="submit" class="btn btn-primary btn-lg" name="edit_account">Add/Update Account</button>
             </form>
         </div>

--- a/root/app/Views/home.php
+++ b/root/app/Views/home.php
@@ -83,8 +83,7 @@ require 'partials/header.php';
                     <input type="hidden" name="account" value="<?php
  echo htmlspecialchars($accountName, ENT_QUOTES) ?>">
                     <input type="hidden" name="username" value="<?php echo $accountOwnerEsc ?>">
-                    <input type="hidden" name="csrf_token" value="<?php
- echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES) ?>">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(App\Core\SessionManager::getInstance()->get('csrf_token'), ENT_QUOTES) ?>">
                     <button type="submit" class="generate-status-button btn btn-success" name="generate_status">Generate Status</button>
                 </form>
             </div>

--- a/root/app/Views/info.php
+++ b/root/app/Views/info.php
@@ -42,10 +42,8 @@
                 <!-- Goal input field -->
                 <label for="goal">Goal:</label>
                 <textarea class="form-input" rows="10" name="goal" id="goal" placeholder="Our goal is... (drive more sales)" maxlength="500" required></textarea>
-                <input name="csrf_token" type="hidden" value="<?php
- echo $_SESSION['csrf_token']; ?>">
-                <input name="accountOwner" type="hidden" value="<?php
- echo htmlspecialchars($_SESSION['username']); ?>">
+                <input name="csrf_token" type="hidden" value="<?php echo App\Core\SessionManager::getInstance()->get('csrf_token'); ?>">
+                <input name="accountOwner" type="hidden" value="<?php echo htmlspecialchars(App\Core\SessionManager::getInstance()->get('username')); ?>">
                 <input class="btn btn-primary btn-lg" type="submit" name="update_profile">
             </form>
         </div>
@@ -57,8 +55,7 @@
             <form class="form-group" method="post">
                 <!-- Username input field (readonly) -->
                 <label for="username">Username:</label>
-                <input class="form-input" type="text" id="username" value="<?php
- echo htmlspecialchars($_SESSION['username']); ?>" readonly>
+                <input class="form-input" type="text" id="username" value="<?php echo htmlspecialchars(App\Core\SessionManager::getInstance()->get('username')); ?>" readonly>
                 <!-- New password input field -->
                 <label for="password">New Password:</label>
                 <input class="form-input" type="password" name="password" id="password" required>
@@ -66,8 +63,7 @@
                 <label for="password2">Confirm New Password:</label>
                 <input class="form-input" type="password" name="password2" id="password2" required>
                 <!-- CSRF token for security -->
-                <input type="hidden" name="csrf_token" value="<?php
- echo $_SESSION['csrf_token']; ?>">
+                <input type="hidden" name="csrf_token" value="<?php echo App\Core\SessionManager::getInstance()->get('csrf_token'); ?>">
                 <input type="submit" class="btn btn-primary btn-lg" name="change_password">
             </form>
             <iframe style="margin: auto;" width="100%" height="340px" src="https://www.youtube.com/embed/Hj-XiPXyqCg?si=TPG2nQ_u1Iz3y_T1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/root/app/Views/login.php
+++ b/root/app/Views/login.php
@@ -33,8 +33,7 @@
             <img class="img-responsive" id="logo" src="assets/images/logo.png" alt="Logo">
             <!-- Login form -->
             <form class="form-group" method="post">
-                <input type="hidden" name="csrf_token" value="<?php
- echo $_SESSION['csrf_token']; ?>">
+                <input type="hidden" name="csrf_token" value="<?php echo App\Core\SessionManager::getInstance()->get('csrf_token'); ?>">
                 <label for="username">Username:</label>
                 <input class="form-input" id="username" type="text" name="username" autocomplete="username" required>
 

--- a/root/app/Views/partials/account-list-item.php
+++ b/root/app/Views/partials/account-list-item.php
@@ -11,7 +11,7 @@
             <button class="btn btn-primary" id="update-button" <?php echo $dataAttributes; ?>>Update</button>
             <form class="delete-account-form" action="/accounts" method="POST">
                 <input type="hidden" name="account" value="<?php echo htmlspecialchars($accountName); ?>">
-                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>">
+                <input type="hidden" name="csrf_token" value="<?php echo App\Core\SessionManager::getInstance()->get('csrf_token'); ?>">
                 <button class="btn btn-error" name="delete_account">Delete</button>
             </form>
         </div>

--- a/root/app/Views/partials/header.php
+++ b/root/app/Views/partials/header.php
@@ -37,7 +37,7 @@
     </div>
     <div class="column col-6 text-right">
         <form action="/login" method="POST" class="form-inline">
-            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(App\Core\SessionManager::getInstance()->get('csrf_token')); ?>">
             <button id="logout" class="btn btn-error" type="submit" name="logout">Logout</button>
         </form>
     </div>
@@ -51,7 +51,7 @@
                         } ?>">
         <a href="/accounts">Accts</a>
     </li>
-    <?php if (isset($_SESSION['is_admin']) && $_SESSION['is_admin']) : ?>
+    <?php if (App\Core\SessionManager::getInstance()->get('is_admin')) : ?>
         <li class="tab-item <?php if ($_SERVER['REQUEST_URI'] === '/users') { echo 'active';
                             } ?>">
             <a href="/users">Users</a>
@@ -61,8 +61,8 @@
                         } ?>">
         <a href="/info">My Info</a>
     </li>
-    <li class="tab-item <?php if ($_SERVER['REQUEST_URI'] === '/feeds/' . htmlspecialchars($_SESSION['username']) . '/all') { echo 'active';
+    <li class="tab-item <?php if ($_SERVER['REQUEST_URI'] === '/feeds/' . htmlspecialchars(App\Core\SessionManager::getInstance()->get('username')) . '/all') { echo 'active';
                         } ?>">
-        <a href="/feeds/<?php echo htmlspecialchars($_SESSION['username']); ?>/all">Omni</a>
+        <a href="/feeds/<?php echo htmlspecialchars(App\Core\SessionManager::getInstance()->get('username')); ?>/all">Omni</a>
     </li>
 </ul>

--- a/root/app/Views/partials/user-list-item.php
+++ b/root/app/Views/partials/user-list-item.php
@@ -12,13 +12,13 @@
             <button class="btn btn-primary" id="update-btn" <?php echo $dataAttributes; ?>>Update</button>
             <form class="delete-user-form" action="/users" method="POST">
                 <input type="hidden" name="username" value="<?php echo htmlspecialchars($user->username); ?>">
-                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(App\Core\SessionManager::getInstance()->get('csrf_token')); ?>">
                 <button class="btn btn-error" name="delete_user">Delete</button>
             </form>
-            <?php if ($user->username !== $_SESSION['username']) : ?>
+            <?php if ($user->username !== App\Core\SessionManager::getInstance()->get('username')) : ?>
                 <form class="login-as-form" action="/users" method="POST">
                     <input type="hidden" name="username" value="<?php echo htmlspecialchars($user->username); ?>">
-                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(App\Core\SessionManager::getInstance()->get('csrf_token')); ?>">
                     <button class="btn btn-primary" name="login_as">Login</button>
                 </form>
             <?php endif; ?>

--- a/root/app/Views/users.php
+++ b/root/app/Views/users.php
@@ -74,8 +74,7 @@ require 'partials/header.php';
                 </select>
 
                 <!-- CSRF token for security -->
-                <input type="hidden" name="csrf_token" value="<?php
- echo htmlspecialchars($_SESSION['csrf_token']); ?>">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(App\Core\SessionManager::getInstance()->get('csrf_token')); ?>">
                 <button class="btn btn-primary btn-lg" type="submit" name="edit_users">Add/Update User</button>
             </form>
         </div>

--- a/root/public/index.php
+++ b/root/public/index.php
@@ -17,17 +17,12 @@ require_once '../vendor/autoload.php';
 
 use App\Core\Router;
 use App\Core\ErrorMiddleware;
+use App\Core\SessionManager;
 
-$secureFlag = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
-session_set_cookie_params([
-    'path'     => '/',
-    'httponly' => true,
-    'secure'   => $secureFlag,
-    'samesite' => 'Lax',
-]);
-session_start();
-if (empty($_SESSION['csrf_token'])) {
-    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+$session = SessionManager::getInstance();
+$session->start();
+if (!$session->get('csrf_token')) {
+    $session->set('csrf_token', bin2hex(random_bytes(32)));
 }
 
 ErrorMiddleware::handle(function (): void {


### PR DESCRIPTION
## Summary
- add a `SessionManager` singleton offering start, destroy, regenerate, get and set helpers for session control
- refactor controllers, middleware and views to retrieve and store session data through `SessionManager`
- document `SessionManager` usage in the README with examples for starting and accessing sessions

## Testing
- `php -l root/app/Core/SessionManager.php`
- `php -l root/public/index.php`
- `php -l root/app/Core/Csrf.php`
- `php -l root/app/Core/ErrorMiddleware.php`
- `php -l root/app/Core/AuthMiddleware.php`
- `php -l root/app/Controllers/AuthController.php`
- `php -l root/app/Controllers/UsersController.php`
- `php -l root/app/Controllers/AccountsController.php`
- `php -l root/app/Controllers/HomeController.php`
- `php -l root/app/Controllers/InfoController.php`
- `php -l root/app/Views/login.php`
- `php -l root/app/Views/partials/account-list-item.php`
- `php -l root/app/Views/partials/header.php`
- `php -l root/app/Views/partials/user-list-item.php`
- `php -l root/app/Views/accounts.php`
- `php -l root/app/Views/info.php`
- `php -l root/app/Views/users.php`
- `php -l root/app/Views/home.php`


------
https://chatgpt.com/codex/tasks/task_e_689990940b6c832a8c1a52e43101b202