### PR TITLE
Refactor session handling in account utilities

### DIFF
--- a/root/app/Controllers/AccountsController.php
+++ b/root/app/Controllers/AccountsController.php
@@ -204,7 +204,6 @@ class AccountsController extends Controller
     private static function generateCalendarOverview(): string
     {
         $session = SessionManager::getInstance();
-        $session = SessionManager::getInstance();
         $username = $session->get('username');
         $accounts = User::getAllUserAccts($username);
 
@@ -339,6 +338,7 @@ class AccountsController extends Controller
      */
     private static function generateAccountList(): string
     {
+        $session = SessionManager::getInstance();
         $username = $session->get('username');
         $accounts = User::getAllUserAccts($username);
         $output = '';


### PR DESCRIPTION
## Summary
- Remove duplicated session instantiation in `generateCalendarOverview`
- Initialize session manager in `generateAccountList` before accessing username

## Testing
- `php -l root/app/Controllers/AccountsController.php`


------
https://chatgpt.com/codex/tasks/task_e_6899d3391e1c832abf43d2fa67099ae8