### PR TITLE
Refactor session message handling into helper

### DIFF
--- a/root/app/Controllers/AccountsController.php
+++ b/root/app/Controllers/AccountsController.php
@@ -20,6 +20,7 @@ use App\Models\User;
 use App\Core\Csrf;
 use App\Core\SessionManager;
 use Respect\Validation\Validator;
+use App\Helpers\MessageHelper;
 
 class AccountsController extends Controller
 {
@@ -52,9 +53,7 @@ class AccountsController extends Controller
     {
         $session = SessionManager::getInstance();
         if (!Csrf::validate($_POST['csrf_token'] ?? '')) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Invalid CSRF token. Please try again.';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Invalid CSRF token. Please try again.');
             header('Location: /accounts');
             exit;
         }
@@ -111,29 +110,19 @@ class AccountsController extends Controller
         }
 
         if ($invalidCron) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Invalid cron hour(s) supplied. Hours must be between 0 and 23.';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Invalid cron hour(s) supplied. Hours must be between 0 and 23.');
         }
         if (empty($cron) || empty($days) || empty($platform) || !isset($hashtags)) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Error processing input.';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Error processing input.');
         }
         if (empty($prompt)) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Missing required field(s).';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Missing required field(s).');
         }
         if (!Validator::alnum('-')->noWhitespace()->lowercase()->length(8, 18)->validate($accountName)) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Account name must be 8-18 characters long, alphanumeric and hyphens only.';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Account name must be 8-18 characters long, alphanumeric and hyphens only.');
         }
         if (!Validator::url()->startsWith('https://')->validate($link)) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Link must be a valid URL starting with https://.';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Link must be a valid URL starting with https://.');
         }
 
         if (!empty($session->get('messages'))) {
@@ -160,13 +149,9 @@ class AccountsController extends Controller
                     );
                 }
             }
-            $messages = $session->get('messages', []);
-            $messages[] = 'Account has been created or modified.';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Account has been created or modified.');
         } catch (\Exception $e) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Failed to create or modify account: ' . $e->getMessage();
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Failed to create or modify account: ' . $e->getMessage());
         }
         header('Location: /accounts');
         exit;
@@ -184,13 +169,9 @@ class AccountsController extends Controller
         $accountOwner = $session->get('username');
         try {
             Account::deleteAccount($accountOwner, $accountName);
-            $messages = $session->get('messages', []);
-            $messages[] = 'Account Deleted.';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Account Deleted.');
         } catch (\Exception $e) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Failed to delete account: ' . $e->getMessage();
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Failed to delete account: ' . $e->getMessage());
         }
         header('Location: /accounts');
         exit;

--- a/root/app/Controllers/InfoController.php
+++ b/root/app/Controllers/InfoController.php
@@ -19,6 +19,7 @@ use App\Models\User;
 use App\Core\Csrf;
 use Respect\Validation\Validator;
 use App\Core\SessionManager;
+use App\Helpers\MessageHelper;
 
 class InfoController extends Controller
 {
@@ -49,9 +50,7 @@ class InfoController extends Controller
         $token = $_POST['csrf_token'] ?? '';
         $session = SessionManager::getInstance();
         if (!Csrf::validate($token)) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Invalid CSRF token. Please try again.';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Invalid CSRF token. Please try again.');
             header('Location: /info');
             exit;
         }
@@ -83,15 +82,11 @@ class InfoController extends Controller
         $password2 = $_POST['password2'];
 
         if ($password !== $password2) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Passwords do not match. Please try again.';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Passwords do not match. Please try again.');
         }
 
         if (!Validator::regex('/^(?=.*[A-Za-z])(?=.*\d)(?=.*[\W_]).{8,16}$/')->validate($password)) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Password must be 8-16 characters long, including at least one letter, one number, and one symbol.';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Password must be 8-16 characters long, including at least one letter, one number, and one symbol.');
         }
 
         if (!empty($session->get('messages'))) {
@@ -102,13 +97,9 @@ class InfoController extends Controller
         $hashedPassword = password_hash($password, PASSWORD_DEFAULT);
         try {
             User::updatePassword($username, $hashedPassword);
-            $messages = $session->get('messages', []);
-            $messages[] = 'Password Updated!';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Password Updated!');
         } catch (\Exception $e) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Password update failed: ' . $e->getMessage();
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Password update failed: ' . $e->getMessage());
         }
         header('Location: /info');
         exit;
@@ -129,22 +120,16 @@ class InfoController extends Controller
         $goal = trim($_POST['goal']);
 
         if (empty($who) || empty($where) || empty($what) || empty($goal)) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'All fields are required.';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('All fields are required.');
             header('Location: /info');
             exit;
         }
 
         try {
             User::updateProfile($username, $who, $where, $what, $goal);
-            $messages = $session->get('messages', []);
-            $messages[] = 'Profile Updated!';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Profile Updated!');
         } catch (\Exception $e) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Profile update failed: ' . $e->getMessage();
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Profile update failed: ' . $e->getMessage());
         }
         header('Location: /info');
         exit;

--- a/root/app/Controllers/LoginController.php
+++ b/root/app/Controllers/LoginController.php
@@ -20,6 +20,7 @@ use App\Core\ErrorManager;
 use App\Core\Controller;
 use App\Core\Csrf;
 use App\Core\SessionManager;
+use App\Helpers\MessageHelper;
 
 class LoginController extends Controller
 {
@@ -51,9 +52,7 @@ class LoginController extends Controller
             if (Csrf::validate($_POST['csrf_token'] ?? '')) {
                 self::logoutUser();
             } else {
-                $messages = $session->get('messages', []);
-                $messages[] = 'Invalid CSRF token. Please try again.';
-                $session->set('messages', $messages);
+                MessageHelper::addMessage('Invalid CSRF token. Please try again.');
                 header('Location: /login');
                 exit();
             }
@@ -67,9 +66,7 @@ class LoginController extends Controller
         if (!Csrf::validate($_POST['csrf_token'] ?? '')) {
             $error = 'Invalid CSRF token. Please try again.';
             ErrorManager::getInstance()->log($error);
-            $messages = $session->get('messages', []);
-            $messages[] = $error;
-            $session->set('messages', $messages);
+            MessageHelper::addMessage($error);
         } else {
             $username = trim($_POST['username'] ?? '');
             $password = trim($_POST['password'] ?? '');
@@ -91,16 +88,12 @@ class LoginController extends Controller
             if (SecurityService::isBlacklisted($ip)) {
                 $error = 'Your IP has been blacklisted due to multiple failed login attempts.';
                 ErrorManager::getInstance()->log($error);
-                $messages = $session->get('messages', []);
-                $messages[] = $error;
-                $session->set('messages', $messages);
+                MessageHelper::addMessage($error);
             } else {
                 SecurityService::updateFailedAttempts($ip);
                 $error = 'Invalid username or password.';
                 ErrorManager::getInstance()->log($error);
-                $messages = $session->get('messages', []);
-                $messages[] = $error;
-                $session->set('messages', $messages);
+                MessageHelper::addMessage($error);
             }
         }
 

--- a/root/app/Controllers/UsersController.php
+++ b/root/app/Controllers/UsersController.php
@@ -20,6 +20,7 @@ use App\Models\User;
 use App\Core\Csrf;
 use App\Core\SessionManager;
 use Respect\Validation\Validator;
+use App\Helpers\MessageHelper;
 
 class UsersController extends Controller
 {
@@ -59,9 +60,7 @@ class UsersController extends Controller
         }
 
         if (!Csrf::validate($_POST['csrf_token'] ?? '')) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Invalid CSRF token. Please try again.';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Invalid CSRF token. Please try again.');
             header('Location: /users');
             exit;
         }
@@ -104,19 +103,13 @@ class UsersController extends Controller
         $admin = intval($_POST['admin']);
 
         if (!Validator::alnum()->noWhitespace()->lowercase()->length(5, 16)->validate($username)) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Username must be 5-16 characters long, lowercase letters and numbers only.';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Username must be 5-16 characters long, lowercase letters and numbers only.');
         }
         if (!empty($password) && !Validator::regex('/^(?=.*[A-Za-z])(?=.*\d)(?=.*[\W_]).{8,16}$/')->validate($password)) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Password must be 8-16 characters long, including at least one letter, one number, and one symbol.';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Password must be 8-16 characters long, including at least one letter, one number, and one symbol.');
         }
         if (!Validator::email()->validate($email)) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Please provide a valid email address.';
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Please provide a valid email address.');
         }
 
         if (!empty($session->get('messages'))) {
@@ -127,9 +120,7 @@ class UsersController extends Controller
         try {
             $userExists = User::userExists($username);
             if (!$userExists && empty($password)) {
-                $messages = $session->get('messages', []);
-                $messages[] = 'Password is required for new users.';
-                $session->set('messages', $messages);
+                MessageHelper::addMessage('Password is required for new users.');
                 header('Location: /users');
                 exit;
             }
@@ -172,18 +163,12 @@ class UsersController extends Controller
                         ]
                     );
                 }
-                $messages = $session->get('messages', []);
-                $messages[] = 'User has been created or modified.';
-                $session->set('messages', $messages);
+                MessageHelper::addMessage('User has been created or modified.');
             } else {
-                $messages = $session->get('messages', []);
-                $messages[] = 'Failed to create or modify user.';
-                $session->set('messages', $messages);
+                MessageHelper::addMessage('Failed to create or modify user.');
             }
         } catch (\Exception $e) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Failed to create or modify user: ' . $e->getMessage();
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Failed to create or modify user: ' . $e->getMessage());
         }
         header('Location: /users');
         exit;
@@ -199,19 +184,13 @@ class UsersController extends Controller
         $session = SessionManager::getInstance();
         $username = $_POST['username'];
         if ($username === $session->get('username')) {
-            $messages = $session->get('messages', []);
-            $messages[] = "Sorry, you can't delete your own account.";
-            $session->set('messages', $messages);
+            MessageHelper::addMessage("Sorry, you can't delete your own account.");
         } else {
             try {
                 User::deleteUser($username);
-                $messages = $session->get('messages', []);
-                $messages[] = 'User Deleted';
-                $session->set('messages', $messages);
+                MessageHelper::addMessage('User Deleted');
             } catch (\Exception $e) {
-                $messages = $session->get('messages', []);
-                $messages[] = 'Failed to delete user: ' . $e->getMessage();
-                $session->set('messages', $messages);
+                MessageHelper::addMessage('Failed to delete user: ' . $e->getMessage());
             }
         }
         header('Location: /users');
@@ -243,14 +222,10 @@ class UsersController extends Controller
                 header('Location: /home');
                 exit;
             } else {
-                $messages = $session->get('messages', []);
-                $messages[] = 'Failed to login as user.';
-                $session->set('messages', $messages);
+                MessageHelper::addMessage('Failed to login as user.');
             }
         } catch (\Exception $e) {
-            $messages = $session->get('messages', []);
-            $messages[] = 'Failed to login as user: ' . $e->getMessage();
-            $session->set('messages', $messages);
+            MessageHelper::addMessage('Failed to login as user: ' . $e->getMessage());
         }
         header('Location: /users');
         exit;

--- a/root/app/Core/ErrorManager.php
+++ b/root/app/Core/ErrorManager.php
@@ -110,18 +110,4 @@ class ErrorManager
         }
     }
 
-    /**
-     * Display and clear session-based messages.
-     */
-    public static function displayAndClearMessages(): void
-    {
-        $session = SessionManager::getInstance();
-        $messages = $session->get('messages', []);
-        if (!empty($messages)) {
-            foreach ($messages as $message) {
-                echo '<script>showToast(' . json_encode($message) . ');</script>';
-            }
-            $session->set('messages', []);
-        }
-    }
 }

--- a/root/app/Helpers/MessageHelper.php
+++ b/root/app/Helpers/MessageHelper.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Project: SocialRSS
+ * Author:  Vontainment <services@vontainment.com>
+ * License: https://opensource.org/licenses/MIT MIT License
+ * Link:    https://vontainment.com
+ * Version: 3.0.0
+ *
+ * File: MessageHelper.php
+ * Description: Helper for managing session-based messages.
+ */
+
+namespace App\Helpers;
+
+use App\Core\SessionManager;
+
+class MessageHelper
+{
+    /**
+     * Add a message to the session queue.
+     *
+     * @param string $message Message to add.
+     * @return void
+     */
+    public static function addMessage(string $message): void
+    {
+        $session = SessionManager::getInstance();
+        $messages = $session->get('messages', []);
+        $messages[] = $message;
+        $session->set('messages', $messages);
+    }
+
+    /**
+     * Display all session messages and clear them.
+     *
+     * @return void
+     */
+    public static function displayAndClearMessages(): void
+    {
+        $session = SessionManager::getInstance();
+        $messages = $session->get('messages', []);
+        if (!empty($messages)) {
+            foreach ($messages as $message) {
+                echo '<script>showToast(' . json_encode($message) . ');</script>';
+            }
+            $session->set('messages', []);
+        }
+    }
+}

--- a/root/app/Views/login.php
+++ b/root/app/Views/login.php
@@ -47,6 +47,6 @@
         </div>
     </div>
 <?php
-    App\Core\ErrorManager::displayAndClearMessages(); ?>
+    App\Helpers\MessageHelper::displayAndClearMessages(); ?>
 </body>
 </html>

--- a/root/app/Views/partials/footer.php
+++ b/root/app/Views/partials/footer.php
@@ -23,6 +23,6 @@
     </div>
 </footer>
 <?php
-    App\Core\ErrorManager::displayAndClearMessages(); ?>
+    App\Helpers\MessageHelper::displayAndClearMessages(); ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Introduce `MessageHelper` to encapsulate session message management and display logic
- Remove message display from `ErrorManager` and update views to use `MessageHelper`
- Refactor controllers to add messages via `MessageHelper::addMessage`

## Testing
- `php -l root/app/Helpers/MessageHelper.php`
- `php -l root/app/Core/ErrorManager.php`
- `php -l root/app/Views/login.php`
- `php -l root/app/Views/partials/footer.php`
- `php -l root/app/Controllers/LoginController.php`
- `php -l root/app/Controllers/InfoController.php`
- `php -l root/app/Controllers/AccountsController.php`
- `php -l root/app/Controllers/HomeController.php`
- `php -l root/app/Controllers/UsersController.php`


------
https://chatgpt.com/codex/tasks/task_e_6899e44a12c0832a8625b8a2fcc11dbf