### PR TITLE
Move security logic to Blacklist model

### DIFF
--- a/root/app/Controllers/LoginController.php
+++ b/root/app/Controllers/LoginController.php
@@ -15,7 +15,7 @@
 namespace App\Controllers;
 
 use App\Models\User;
-use App\Services\SecurityService;
+use App\Models\Blacklist;
 use App\Core\ErrorManager;
 use App\Core\Controller;
 use App\Core\Csrf;
@@ -88,14 +88,14 @@ class LoginController extends Controller
             }
 
             $ip = $_SERVER['REMOTE_ADDR'];
-            if (SecurityService::isBlacklisted($ip)) {
+            if (Blacklist::isBlacklisted($ip)) {
                 $error = 'Your IP has been blacklisted due to multiple failed login attempts.';
                 ErrorManager::getInstance()->log($error);
                 $messages = $session->get('messages', []);
                 $messages[] = $error;
                 $session->set('messages', $messages);
             } else {
-                SecurityService::updateFailedAttempts($ip);
+                Blacklist::updateFailedAttempts($ip);
                 $error = 'Invalid username or password.';
                 ErrorManager::getInstance()->log($error);
                 $messages = $session->get('messages', []);

--- a/root/app/Core/SessionManager.php
+++ b/root/app/Core/SessionManager.php
@@ -14,7 +14,7 @@
 
 namespace App\Core;
 
-use App\Services\SecurityService;
+use App\Models\Blacklist;
 use App\Core\ErrorManager;
 
 class SessionManager
@@ -146,7 +146,7 @@ class SessionManager
     public function requireAuth(): void
     {
         $ip = filter_var($_SERVER['REMOTE_ADDR'] ?? '', FILTER_VALIDATE_IP);
-        if ($ip && SecurityService::isBlacklisted($ip)) {
+        if ($ip && Blacklist::isBlacklisted($ip)) {
             http_response_code(403);
             ErrorManager::getInstance()->log("Blacklisted IP attempted access: $ip", 'error');
             exit();

--- a/root/app/Models/Blacklist.php
+++ b/root/app/Models/Blacklist.php
@@ -8,17 +8,17 @@
  * Link:    https://vontainment.com
  * Version: 3.0.0
  *
- * File: SecurityService.php
+ * File: Blacklist.php
  * Description: IP blacklist management
  */
 
-namespace App\Services;
+namespace App\Models;
 
 use Exception;
 use App\Core\DatabaseManager;
 use App\Core\ErrorManager;
 
-class SecurityService
+class Blacklist
 {
     /**
      * Update the failed login attempts for an IP address.

--- a/root/app/Services/CronService.php
+++ b/root/app/Services/CronService.php
@@ -20,7 +20,7 @@ use App\Models\Account;
 use App\Models\User;
 use App\Models\Status;
 use App\Core\Mailer;
-use App\Services\SecurityService;
+use App\Models\Blacklist;
 
 class CronService
 {
@@ -102,6 +102,6 @@ class CronService
      */
     public function purgeIps(): bool
     {
-        return SecurityService::clearIpBlacklist();
+        return Blacklist::clearIpBlacklist();
     }
 }


### PR DESCRIPTION
## Summary
- Replace SecurityService with Blacklist model for IP blacklist logic
- Update session, login, and cron services to reference Blacklist model

## Testing
- `php -l root/app/Models/Blacklist.php`
- `php -l root/app/Core/SessionManager.php`
- `php -l root/app/Controllers/LoginController.php`
- `php -l root/app/Services/CronService.php`
- `cd root && composer dump-autoload`


------
https://chatgpt.com/codex/tasks/task_e_6899e446e990832a846151ef73f3f396