### PR TITLE
refactor: make router a singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ use App\Core\DatabaseManager;
 $db = DatabaseManager::getInstance();
 ```
 
+### Routing
+
+The router is exposed as a singleton. Use the shared instance to dispatch requests:
+
+```php
+use App\Core\Router;
+
+Router::getInstance()->dispatch($method, $uri);
+```
+
+This ensures the underlying FastRoute dispatcher is constructed only once.
+
 ### Session Management
 
 Manage sessions through the `SessionManager` singleton:

--- a/root/app/Core/Router.php
+++ b/root/app/Core/Router.php
@@ -21,11 +21,12 @@ use function FastRoute\simpleDispatcher;
 class Router
 {
     private Dispatcher $dispatcher;
+    private static ?Router $instance = null;
 
     /**
      * Builds the route dispatcher and registers application routes.
      */
-    public function __construct()
+    private function __construct()
     {
         $this->dispatcher = simpleDispatcher(function (RouteCollector $r): void {
             // Redirect the root URL to the home page for convenience
@@ -53,6 +54,18 @@ class Router
             // Feed routes
             $r->addRoute('GET', '/feeds/{user}/{account}', [\App\Controllers\FeedController::class, 'handleRequest']);
         });
+    }
+
+    /**
+     * Returns the shared Router instance.
+     */
+    public static function getInstance(): Router
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
     }
 
     /**

--- a/root/public/index.php
+++ b/root/public/index.php
@@ -26,7 +26,6 @@ if (!$session->get('csrf_token')) {
 }
 
 ErrorManager::handle(function (): void {
-    $router = new Router();
     $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-    $router->dispatch($_SERVER['REQUEST_METHOD'], $uri);
+    Router::getInstance()->dispatch($_SERVER['REQUEST_METHOD'], $uri);
 });


### PR DESCRIPTION
## Summary
- refactor Router into a lazy singleton exposing `getInstance`
- update public entry point to use the shared Router instance
- document router singleton usage in README

## Testing
- `php -l root/app/Core/Router.php`
- `php -l root/public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6899e681a278832aa822e11d927f7a34