### PR TITLE
feat: persistent job status and retry handling

### DIFF
--- a/root/app/Services/QueueService.php
+++ b/root/app/Services/QueueService.php
@@ -5,6 +5,8 @@ namespace App\Services;
 
 use Enqueue\Dbal\DbalConnectionFactory;
 use App\Services\StatusService;
+use App\Models\Account;
+use App\Core\DatabaseManager;
 
 class QueueService
 {
@@ -30,22 +32,114 @@ class QueueService
         $this->queue = $this->context->createQueue('status');
     }
 
-    public function enqueueStatus(string $username, string $account): void
+    public function clearQueue(): void
     {
-        $payload = json_encode(['username' => $username, 'account' => $account]);
+        $db = DatabaseManager::getInstance();
+        $db->query('TRUNCATE TABLE status_jobs');
+        $db->execute();
+    }
+
+    private function enqueueStatusForHour(string $username, string $account, int $hour): void
+    {
+        $payload = json_encode(['username' => $username, 'account' => $account, 'hour' => $hour]);
         $message = $this->context->createMessage($payload);
         $this->context->createProducer()->send($this->queue, $message);
     }
 
+    public function enqueueDailyJobs(): void
+    {
+        $accounts = Account::getAllAccounts();
+        $dayName = strtolower(date('l'));
+        foreach ($accounts as $account) {
+            $days = array_map('strtolower', array_map('trim', explode(',', (string) $account->days)));
+            if (!in_array('everyday', $days) && !in_array($dayName, $days)) {
+                continue;
+            }
+            $hours = array_filter(array_map('trim', explode(',', (string) $account->cron)), 'strlen');
+            foreach ($hours as $hour) {
+                $this->enqueueStatusForHour($account->username, $account->account, (int) $hour);
+            }
+        }
+    }
+
+    public function enqueueRemainingJobs(string $username, string $account, string $cron, string $days): void
+    {
+        $dayName = strtolower(date('l'));
+        $currentHour = (int) date('G');
+        $daysArr = array_map('strtolower', array_map('trim', explode(',', $days)));
+        if (!in_array('everyday', $daysArr) && !in_array($dayName, $daysArr)) {
+            return;
+        }
+        $hours = array_filter(array_map('trim', explode(',', $cron)), 'strlen');
+        foreach ($hours as $hour) {
+            $intHour = (int) $hour;
+            if ($intHour > $currentHour) {
+                $this->enqueueStatusForHour($username, $account, $intHour);
+            }
+        }
+    }
+
+    public function removeFutureJobs(string $username, string $account): void
+    {
+        $currentHour = (int) date('G');
+        $db = DatabaseManager::getInstance();
+        $db->query("DELETE FROM status_jobs WHERE status IN ('pending','retry') AND JSON_EXTRACT(body, '\$.username') = :user AND JSON_EXTRACT(body, '\$.account') = :acct AND JSON_EXTRACT(body, '\$.hour') >= :hr");
+        $db->bind(':user', $username);
+        $db->bind(':acct', $account);
+        $db->bind(':hr', $currentHour);
+        $db->execute();
+    }
+
     public function runQueue(): void
     {
-        $consumer = $this->context->createConsumer($this->queue);
-        while ($message = $consumer->receiveNoWait()) {
-            $data = json_decode($message->getBody(), true);
-            if (is_array($data) && isset($data['username'], $data['account'])) {
-                StatusService::generateStatus($data['account'], $data['username']);
+        $db = DatabaseManager::getInstance();
+        $currentHour = (int) date('G');
+
+        // Retry jobs first
+        $db->query("SELECT id, body, attempts, status FROM status_jobs WHERE status = 'retry'");
+        $retryJobs = $db->resultSet();
+        foreach ($retryJobs as $job) {
+            $this->processJob($job);
+        }
+
+        // Pending jobs for current hour
+        $db->query("SELECT id, body, attempts, status FROM status_jobs WHERE status = 'pending'");
+        $pendingJobs = $db->resultSet();
+        foreach ($pendingJobs as $job) {
+            $data = json_decode($job['body'], true);
+            if (!is_array($data) || !isset($data['hour']) || (int) $data['hour'] > $currentHour) {
+                continue;
             }
-            $consumer->acknowledge($message);
+            $this->processJob($job);
+        }
+    }
+
+    private function processJob(array $job): void
+    {
+        $db = DatabaseManager::getInstance();
+        $data = json_decode($job['body'], true);
+        $id = $job['id'];
+        $attempts = (int) ($job['attempts'] ?? 0);
+        if (!is_array($data) || !isset($data['username'], $data['account'])) {
+            $db->query("UPDATE status_jobs SET status = 'failed' WHERE id = :id");
+            $db->bind(':id', $id);
+            $db->execute();
+            return;
+        }
+
+        try {
+            StatusService::generateStatus($data['account'], $data['username']);
+            $db->query("UPDATE status_jobs SET status = 'done' WHERE id = :id");
+            $db->bind(':id', $id);
+            $db->execute();
+        } catch (\Exception $e) {
+            $newStatus = $job['status'] === 'retry' ? 'failed' : 'retry';
+            $attempts++;
+            $db->query('UPDATE status_jobs SET status = :status, attempts = :attempts WHERE id = :id');
+            $db->bind(':status', $newStatus);
+            $db->bind(':attempts', $attempts);
+            $db->bind(':id', $id);
+            $db->execute();
         }
     }
 }


### PR DESCRIPTION
## Summary
- track job lifecycle with `status` and `attempts` columns
- reset queue daily and enqueue jobs for the whole day
- prioritize retry jobs and adjust queue on account changes

## Testing
- `php -l root/cron.php`
- `php -l root/app/Services/QueueService.php`
- `php -l root/app/Controllers/AccountsController.php`


------
https://chatgpt.com/codex/tasks/task_e_6899eccf8a08832ab2e508237f5e52c4