### PR TITLE
Clean up queued jobs when deleting accounts

### DIFF
--- a/root/app/Controllers/AccountsController.php
+++ b/root/app/Controllers/AccountsController.php
@@ -177,6 +177,8 @@ class AccountsController extends Controller
         $accountOwner = $session->get('username');
         try {
             Account::deleteAccount($accountOwner, $accountName);
+            $queueService = new QueueService();
+            $queueService->removeAllJobs($accountOwner, $accountName);
             MessageHelper::addMessage('Account Deleted.');
         } catch (\Exception $e) {
             MessageHelper::addMessage('Failed to delete account: ' . $e->getMessage());

--- a/root/app/Services/QueueService.php
+++ b/root/app/Services/QueueService.php
@@ -90,6 +90,15 @@ class QueueService
         $db->execute();
     }
 
+    public function removeAllJobs(string $username, string $account): void
+    {
+        $db = DatabaseManager::getInstance();
+        $db->query("DELETE FROM status_jobs WHERE JSON_EXTRACT(body, '\$.username') = :user AND JSON_EXTRACT(body, '\$.account') = :acct");
+        $db->bind(':user', $username);
+        $db->bind(':acct', $account);
+        $db->execute();
+    }
+
     public function runQueue(): void
     {
         $db = DatabaseManager::getInstance();


### PR DESCRIPTION
## Summary
- Delete all queued jobs for a user/account pair via new `QueueService::removeAllJobs`
- Invoke job cleanup in `AccountsController::deleteAccount`

## Testing
- `php -l root/app/Services/QueueService.php`
- `php -l root/app/Controllers/AccountsController.php`


------
https://chatgpt.com/codex/tasks/task_e_6899fe6bccd8832a963943778c94d5a2