### PR TITLE
Refactor queue processing to worker consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,12 +163,13 @@ Install the project using the following steps:
 6. **Set Up Cron Jobs:**
   - Configure two cron schedules:
     ```sh
-    0 0 * * * /usr/bin/php /PATH-TO-APP/cron.php
-    0 * * * * /usr/bin/php /PATH-TO-APP/bin/status-worker.php --once
+    0 0 * * * /usr/bin/php /PATH-TO-APP/cron.php daily
+    0 * * * * /usr/bin/php /PATH-TO-APP/cron.php hourly
     ```
   - Replace `/PATH-TO-APP/` with the actual path to your installation.
   - **Daily:** purges old data and populates the job queue for the day.
-  - **Hourly:** invokes the queue worker once to process jobs for the current hour. For a persistent worker, run `bin/status-worker.php` without `--once` under Supervisor or systemd.
+  - **Hourly:** processes queued jobs for the current hour.
+  - To run a persistent worker instead of the hourly cron, execute `bin/status-worker.php` without `--once` under Supervisor or systemd.
 
 ### Queue Table
 

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ Install the project using the following steps:
     0 * * * * /usr/bin/php /PATH-TO-APP/cron.php hourly
     ```
   - Replace `/PATH-TO-APP/` with the actual path to your installation.
-  - **Daily:** purges old data and populates the job queue for the day.
-  - **Hourly:** processes queued jobs for the current hour.
+   - **Daily:** populates the job queue; on the 1st, it also purges old statuses and images.
+   - **Hourly:** processes queued jobs for the current hour.
   - To run a persistent worker instead of the hourly cron, execute `bin/status-worker.php` without `--once` under Supervisor or systemd.
 
 ### Queue Table

--- a/README.md
+++ b/README.md
@@ -163,20 +163,19 @@ Install the project using the following steps:
 6. **Set Up Cron Jobs:**
   - Configure two cron schedules:
     ```sh
-   0 0 * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php daily
-   0 * * * * /usr/bin/php /PATH-TO-CRON.PHP/cron.php hourly
+    0 0 * * * /usr/bin/php /PATH-TO-APP/cron.php
+    0 * * * * /usr/bin/php /PATH-TO-APP/bin/status-worker.php --once
     ```
-  - Replace `/PATH-TO-CRON.PHP/` with the actual path to your `cron.php` file.
-  - **Daily:** runs `purge_ips`; `reset_usage` also runs but only on the first day of the month.
-  - **Hourly:** purges old statuses and images, enqueues any posts scheduled for the current hour, and processes them immediately.
+  - Replace `/PATH-TO-APP/` with the actual path to your installation.
+  - **Daily:** purges old data and populates the job queue for the day.
+  - **Hourly:** invokes the queue worker once to process jobs for the current hour. For a persistent worker, run `bin/status-worker.php` without `--once` under Supervisor or systemd.
 
 ### Queue Table
 
 The `status_jobs` table uses Enqueue's DBAL schema. Each message stores a JSON
-payload identifying the user and account that needs a status update. During the
-hourly cron run, the application enqueues jobs for the current hour and then
-consumes them immediately. Successfully processed messages are acknowledged and
-removed from the table.
+payload identifying the user and account that needs a status update. The daily
+cron populates the table with jobs for the current day, and the worker script
+consumes them, relying on Enqueue for locking and redelivery.
 
 ### 🤖 Usage
 

--- a/root/app/Services/CronService.php
+++ b/root/app/Services/CronService.php
@@ -16,6 +16,8 @@ namespace App\Services;
 
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
+use Enqueue\Dbal\DbalConnectionFactory;
+use Enqueue\Util\JSON;
 use App\Models\Account;
 use App\Models\User;
 use App\Models\Status;
@@ -103,5 +105,65 @@ class CronService
     public function purgeIps(): bool
     {
         return Blacklist::clearIpBlacklist();
+    }
+
+    /**
+     * Truncate previous jobs and enqueue all of today's jobs.
+     */
+    public function scheduleDailyQueue(): void
+    {
+        $factory = new DbalConnectionFactory([
+            'connection' => [
+                'dbname' => DB_NAME,
+                'user' => DB_USER,
+                'password' => DB_PASSWORD,
+                'host' => DB_HOST,
+                'driver' => 'pdo_mysql',
+                'charset' => 'utf8mb4',
+            ],
+            'table_name' => 'status_jobs',
+            'lazy' => false,
+        ]);
+
+        $context = $factory->createContext();
+        $context->getDbalConnection()->executeStatement('TRUNCATE TABLE status_jobs');
+
+        $queue = $context->createQueue('status_generate');
+        $producer = $context->createProducer();
+
+        $accounts = Account::getAllAccounts();
+        $dayName = strtolower(date('l'));
+
+        foreach ($accounts as $account) {
+            $days = array_map('strtolower', array_map('trim', explode(',', (string) $account->days)));
+            if (!in_array('everyday', $days, true) && !in_array($dayName, $days, true)) {
+                continue;
+            }
+            $hours = array_filter(array_map('trim', explode(',', (string) $account->cron)), 'strlen');
+            foreach ($hours as $hour) {
+                $payload = [
+                    'username' => $account->username,
+                    'account' => $account->account,
+                    'hour' => (int) $hour,
+                ];
+                $message = $context->createMessage(JSON::encode($payload));
+                $message->setContentType('application/json');
+                $producer->send($queue, $message);
+            }
+        }
+    }
+
+    /**
+     * Run all daily maintenance tasks.
+     */
+    public function runDaily(): void
+    {
+        if (date('j') === '1') {
+            $this->resetApi();
+        }
+        $this->purgeIps();
+        $this->purgeStatuses();
+        $this->purgeImages();
+        $this->scheduleDailyQueue();
     }
 }

--- a/root/app/Services/CronService.php
+++ b/root/app/Services/CronService.php
@@ -158,8 +158,7 @@ class CronService
      */
     public function runHourly(): void
     {
-        $this->purgeStatuses();
-        $this->purgeImages();
+        // No hourly maintenance tasks currently.
     }
 
     /**
@@ -169,10 +168,10 @@ class CronService
     {
         if (date('j') === '1') {
             $this->resetApi();
+            $this->purgeStatuses();
+            $this->purgeImages();
         }
         $this->purgeIps();
-        $this->purgeStatuses();
-        $this->purgeImages();
         $this->scheduleDailyQueue();
     }
 }

--- a/root/app/Services/CronService.php
+++ b/root/app/Services/CronService.php
@@ -148,9 +148,18 @@ class CronService
                 ];
                 $message = $context->createMessage(JSON::encode($payload));
                 $message->setContentType('application/json');
-                $producer->send($queue, $message);
+        $producer->send($queue, $message);
             }
         }
+    }
+
+    /**
+     * Run hourly maintenance tasks.
+     */
+    public function runHourly(): void
+    {
+        $this->purgeStatuses();
+        $this->purgeImages();
     }
 
     /**

--- a/root/bin/status-worker.php
+++ b/root/bin/status-worker.php
@@ -1,0 +1,11 @@
+<?php
+// phpcs:ignoreFile PSR1.Files.SideEffects.FoundWithSymbols
+
+require __DIR__ . '/../config.php';
+require __DIR__ . '/../vendor/autoload.php';
+
+use App\Services\QueueService;
+
+$once = in_array('--once', $argv, true);
+$service = new QueueService();
+$service->processLoop($once);


### PR DESCRIPTION
## Summary
- schedule daily status jobs and purge queue using DbalConnectionFactory
- process queue messages via QueueConsumer with hourly retry logic
- document new worker script and cron usage

## Testing
- `php -l root/app/Services/CronService.php`
- `php -l root/app/Services/QueueService.php`
- `php -l root/cron.php`
- `php -l root/bin/status-worker.php`


------
https://chatgpt.com/codex/tasks/task_e_689a1229bde4832abbfc92bb5932159c