### PR TITLE
chore: align tooling paths and add tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,6 @@
 {
+  "root": true,
+  "ignorePatterns": ["root/vendor/**"],
   "env": {
     "browser": true,
     "es2021": true

--- a/.github/phpstan-bootstrap.php
+++ b/.github/phpstan-bootstrap.php
@@ -4,8 +4,7 @@ $rootDir = dirname(__DIR__);
 
 // Load Composer autoload from root
 $autoloadFiles = [
-    $rootDir . '/vendor/autoload.php',
-    $rootDir . '/update-api/vendor/autoload.php',
+    $rootDir . '/root/vendor/autoload.php',
 ];
 foreach ($autoloadFiles as $file) {
     if (is_file($file)) {

--- a/.github/workflows/pr-auto-fix.yml
+++ b/.github/workflows/pr-auto-fix.yml
@@ -28,16 +28,15 @@ jobs:
         shell: bash
         run: |
           TARGETS=""
-          [ -d mu-plugin ] && TARGETS="$TARGETS mu-plugin"
-          [ -d update-api ] && TARGETS="$TARGETS update-api"
+          [ -d root/app ] && TARGETS="$TARGETS root/app"
 
           if [ -z "$TARGETS" ]; then
             echo "No target dirs found. Skipping PHPCBF."
             exit 0
           fi
 
-          if [ -f vendor/bin/phpcbf ]; then
-            php vendor/bin/phpcbf --standard=phpcs.xml $TARGETS || true
+          if [ -f root/vendor/bin/phpcbf ]; then
+            php root/vendor/bin/phpcbf --standard=phpcs.xml $TARGETS || true
           elif command -v phpcbf >/dev/null 2>&1; then
             phpcbf --standard=phpcs.xml $TARGETS || true
           else
@@ -49,14 +48,13 @@ jobs:
         shell: bash
         run: |
           if [ -f node_modules/eslint/bin/eslint.js ]; then
-            if find update-api -type f -name "*.js" ! -path "*/vendor/*" | grep -q .; then
+            if find root/public/assets/js -type f -name "*.js" ! -path "*/vendor/*" | grep -q .; then
               node node_modules/eslint/bin/eslint.js \
-                "update-api/**/*.js" \
-                --ignore-pattern "vendor/**" \
-                --ignore-pattern "update-api/vendor/**" \
+                "root/public/assets/js/**/*.js" \
+                --ignore-pattern "root/vendor/**" \
                 --fix || true
             else
-              echo "No JS files under update-api/. Skipping ESLint."
+              echo "No JS files under root/public/assets/js. Skipping ESLint."
             fi
           else
             echo "ESLint not installed locally. Skipping."
@@ -67,14 +65,13 @@ jobs:
         shell: bash
         run: |
           if [ -f node_modules/stylelint/bin/stylelint.mjs ]; then
-            if find update-api -type f -name "*.css" ! -path "*/vendor/*" | grep -q .; then
+            if find root/public/assets/css -type f -name "*.css" ! -path "*/vendor/*" | grep -q .; then
               node node_modules/stylelint/bin/stylelint.mjs \
-                "update-api/**/*.css" \
-                --ignore-pattern "vendor/**" \
-                --ignore-pattern "update-api/vendor/**" \
+                "root/public/assets/css/**/*.css" \
+                --ignore-pattern "root/vendor/**" \
                 --fix || true
             else
-              echo "No CSS files under update-api/. Skipping Stylelint."
+              echo "No CSS files under root/public/assets/css. Skipping Stylelint."
             fi
           else
             echo "Stylelint not installed locally. Skipping."

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 *.code-workspace
 
 # Ensure these files are ignored no matter where they are located
-/phpcs.xml
 /composer.lock
 /composer.json
 

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,7 @@
 {
+  "root": true,
   "extends": "stylelint-config-standard",
+  "ignoreFiles": ["root/vendor/**"],
   "rules": {
     "indentation": 2,
     "color-hex-length": "short"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## Unreleased
+### Added
+- Initialized coding standards and test suite.
+- Updated tooling paths and bootstrap references.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<ruleset name="Project Coding Standards">
+    <rule ref="PSR12"/>
+    <exclude-pattern>root/vendor/*</exclude-pattern>
+</ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,13 +1,14 @@
 parameters:
   level: 6
   paths:
-    - mu-plugin
-    - update-api
+    - root/app
+    - root/cron.php
+    - root/config.php
+    - root/public
   excludePaths:
-    - update-api/vendor
-    - update-api/vendor/*
+    - root/vendor
   bootstrapFiles:
-    - .github\phpstan-bootstrap.php
+    - .github/phpstan-bootstrap.php
 
   # Optional: silence WP globals noise you don’t care about
   ignoreErrors:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit bootstrap="root/vendor/autoload.php"
          colors="true"
          verbose="true"
          stopOnFailure="false">
     <testsuites>
         <testsuite name="Application Test Suite">
-            <directory>tests</directory>
+            <directory>root/tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/root/tests/ExampleTest.php
+++ b/root/tests/ExampleTest.php
@@ -1,0 +1,10 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ExampleTest extends TestCase
+{
+    public function testTrue(): void
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Summary
- update PR auto-fix workflow to target `root/app` and public asset paths
- streamline PHPStan bootstrap and config
- mark lint configs as project root, add phpcs ruleset, and seed test suite

## Testing
- `php -d memory_limit=512M phpstan.phar analyse --configuration=phpstan.neon` *(fails: Found 63 errors)*
- `php phpcs.phar --standard=phpcs.xml --extensions=php -v root/app root/cron.php root/config.php root/public`
- `npx --yes eslint@8 -c .eslintrc.json root/public/assets/js --ignore-pattern 'root/vendor/**'`
- `npx stylelint root/public/assets/css --ignore-pattern 'root/vendor/**' -c .stylelintrc.json` *(fails: 131 errors)*
- `php phpunit.phar -c phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68c204e8c7d4832a9c5e7f30e25367cd